### PR TITLE
M1: Unify dev experience — workspaces, ports, env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Backend
+PORT=3456                                    # Backend server port
+
+# Dashboard
+VITE_API_BASE=http://localhost:3456/api       # Backend API URL for dashboard
+
+# MCP Server
+TEAM_MEMORY_URL=http://localhost:3456         # Backend URL for MCP server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,36 +21,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Backend
-      - name: Install backend dependencies
-        working-directory: packages/backend
+      - name: Install all dependencies
         run: npm install
 
-      - name: Build backend
-        working-directory: packages/backend
+      - name: Build all packages
         run: npm run build
-
-      # MCP Server
-      - name: Install MCP server dependencies
-        working-directory: packages/mcp-server
-        run: npm install
-
-      - name: Build MCP server
-        working-directory: packages/mcp-server
-        run: npm run build
-
-      # Dashboard
-      - name: Install dashboard dependencies
-        working-directory: packages/dashboard
-        run: npm install
 
       - name: Lint dashboard
-        working-directory: packages/dashboard
         run: npm run lint
-
-      - name: Build dashboard
-        working-directory: packages/dashboard
-        run: npm run build
 
       # E2E
       - name: Start backend for E2E

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "team-memory",
+  "private": true,
+  "workspaces": [
+    "packages/backend",
+    "packages/mcp-server",
+    "packages/dashboard"
+  ],
+  "scripts": {
+    "dev": "npm run dev:backend & npm run dev:dashboard & wait",
+    "dev:backend": "npm run dev --workspace=packages/backend",
+    "dev:dashboard": "npm run dev --workspace=packages/dashboard",
+    "dev:mcp": "npm run dev --workspace=packages/mcp-server",
+    "build": "npm run build --workspace=packages/backend && npm run build --workspace=packages/mcp-server && npm run build --workspace=packages/dashboard",
+    "lint": "npm run lint --workspace=packages/dashboard"
+  }
+}

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -1,7 +1,7 @@
 import type { KnowledgeItem, KnowledgeListItem } from "./types";
 import { mockKnowledge } from "./mockData";
 
-const API_BASE = "http://localhost:3457/api";
+const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:3456/api";
 const USE_MOCK = false;
 
 interface ListParams {


### PR DESCRIPTION
## Summary
- Root `package.json` with npm workspaces — `npm install` once installs all packages
- `npm run dev` starts backend + dashboard concurrently
- Fixed dashboard port mismatch: was 3457, now defaults to 3456 (matching backend)
- Dashboard API URL now configurable via `VITE_API_BASE` env var
- `.env.example` documenting all configurable env vars (PORT, VITE_API_BASE, TEAM_MEMORY_URL)
- Simplified CI: single workspace install + build instead of per-package steps

## Port convention
| Service | Port | Env var |
|---------|------|---------|
| Backend | 3456 | `PORT` |
| Dashboard | 5173 | (Vite default) |
| MCP Server | stdio | n/a |

## Test plan
- [ ] `npm install` from root installs all packages
- [ ] `npm run dev` starts backend on 3456 + dashboard on 5173
- [ ] Dashboard connects to backend at 3456
- [ ] CI passes (build + lint + E2E)

Task #16 — @umiri (DevOps)