### PR TITLE
docs: agent behavior protocol + integration templates (M3)

### DIFF
--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -31,10 +31,11 @@ publish_knowledge({
   project: "project-name",
   tags: ["relevant", "tags"],
   confidence: "high",
-  staleness_hint: "Recheck when X changes",
-  owner: "your-agent-name"
+  staleness_hint: "Recheck when X changes"
 })
 ```
+
+> **Note on `owner`:** With API key auth (M2), `owner` is automatically derived from your API key. You do not need to pass it explicitly. If auth is not yet enabled, pass `owner: "your-agent-name"` manually.
 
 Not everything needs to be published. Publish when:
 - You discovered something that other agents are likely to need
@@ -137,7 +138,6 @@ publish_knowledge({
   tags: ["billing", "security"],
   confidence: "high",
   staleness_hint: "Recheck if webhook handler is refactored",
-  owner: "Spike",
   related_to: ["abc-123"]
 })
 ```
@@ -154,7 +154,6 @@ publish_knowledge({
   tags: ["auth", "architecture"],
   confidence: "high",
   staleness_hint: "Recheck if auth middleware is refactored",
-  owner: "Ein",
   supersedes: "xyz-789"
 })
 ```

--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -1,0 +1,170 @@
+# Agent Behavior Protocol for Team Memory
+
+This document defines how agents should interact with Team Memory in their daily workflows. The goal is simple: **no agent should redo work that another agent already published**.
+
+## Core Workflow
+
+### 1. Query Before Work
+
+Before starting any task, query Team Memory for existing knowledge:
+
+```
+query_knowledge({ query: "<task topic>", project: "<project>" })
+```
+
+If results are found, read the full item:
+
+```
+get_knowledge({ id: "<matched-id>" })
+```
+
+Use existing knowledge as context. Skip analysis that has already been done. If the existing knowledge is outdated, supersede it (see below).
+
+### 2. Publish After Work
+
+After completing a task that produced a reusable conclusion, publish it:
+
+```
+publish_knowledge({
+  claim: "One falsifiable conclusion",
+  source: ["file.ts", "https://..."],
+  project: "project-name",
+  tags: ["relevant", "tags"],
+  confidence: "high",
+  staleness_hint: "Recheck when X changes",
+  owner: "your-agent-name"
+})
+```
+
+Not everything needs to be published. Publish when:
+- You discovered something that other agents are likely to need
+- You verified a non-obvious fact about the codebase or system
+- You made an architectural or design decision with rationale
+
+Do NOT publish:
+- Ephemeral task status ("I started working on X")
+- Obvious facts derivable from reading the code
+- Conversation summaries or meeting notes
+
+### 3. Supersede When Facts Change
+
+If you discover that an existing knowledge item is wrong or outdated:
+
+```
+publish_knowledge({
+  claim: "Updated conclusion",
+  ...other fields,
+  supersedes: "<old-item-id>"
+})
+```
+
+Do NOT use `update_knowledge` to change the meaning of a claim. `update_knowledge` is for metadata corrections only (tags, confidence, staleness_hint, related_to).
+
+## Writing Good Claims
+
+A claim should be **one falsifiable conclusion**, not a vague note.
+
+| Bad | Good |
+|-----|------|
+| "Looked at the deploy system" | "infer-monorepo uses DEPLOY_MODE env var to switch between control and inference modes" |
+| "Auth is complicated" | "The auth middleware stores session tokens in cookies, not in the database" |
+| "Billing might have issues" | "saved_usd calculation double-counts refunds when a subscription is cancelled mid-cycle" |
+
+Rules:
+- One claim per item. If you have three findings, publish three items.
+- Be specific enough that another agent can act on it without reading the source.
+- Include the "so what" -- why does this matter for the project?
+
+## Choosing Confidence
+
+| Level | Meaning | When to use |
+|-------|---------|-------------|
+| `high` | Verified by reading code or running tests | You traced the code path, ran the test, saw the output |
+| `medium` | Strong evidence but not fully verified | You read the code but didn't test edge cases |
+| `low` | Inferred or suspected | Pattern-based reasoning, secondhand information |
+
+When in doubt, use `medium`. A `low` confidence item is still more useful than no item at all.
+
+## Writing Staleness Hints
+
+A staleness hint tells future agents **when to re-verify** this knowledge.
+
+| Bad | Good |
+|-----|------|
+| "Might change" | "Recheck if DEPLOY_MODE logic in app.py changes" |
+| "Probably stable" | "Stable unless billing provider API version is upgraded" |
+| "Check periodically" | "Re-verify after next database migration" |
+
+Be specific about the trigger condition, not about time.
+
+## Using related_to
+
+Link knowledge items that are conceptually connected:
+
+```
+publish_knowledge({
+  claim: "...",
+  related_to: ["<id-of-related-item>"],
+  ...
+})
+```
+
+Use this when:
+- Two items are about the same subsystem from different angles
+- One item provides context that helps understand another
+- Items represent alternatives or trade-offs
+
+## Workflow Examples
+
+### Example 1: Starting a New Task
+
+```
+# Step 1: Check what's known
+query_knowledge({ query: "billing refund", project: "infer-monorepo" })
+
+# Step 2: Found relevant item, read full detail
+get_knowledge({ id: "abc-123" })
+
+# Step 3: Use that context in your work, skip re-analysis
+# ...do the task...
+
+# Step 4: Publish your new finding
+publish_knowledge({
+  claim: "Refund webhook handler in billing/webhooks.ts does not validate event signatures",
+  source: ["billing/webhooks.ts:42-58"],
+  project: "infer-monorepo",
+  module: "billing",
+  tags: ["billing", "security"],
+  confidence: "high",
+  staleness_hint: "Recheck if webhook handler is refactored",
+  owner: "Spike",
+  related_to: ["abc-123"]
+})
+```
+
+### Example 2: Correcting Outdated Knowledge
+
+```
+# Found that item xyz-789 says "auth uses JWT" but it's been changed to session cookies
+publish_knowledge({
+  claim: "Auth middleware now uses session cookies instead of JWT (changed in PR #45)",
+  source: ["auth/middleware.ts", "PR #45"],
+  project: "infer-monorepo",
+  module: "auth",
+  tags: ["auth", "architecture"],
+  confidence: "high",
+  staleness_hint: "Recheck if auth middleware is refactored",
+  owner: "Ein",
+  supersedes: "xyz-789"
+})
+```
+
+### Example 3: Cold-Start Exploration
+
+```
+# New to the project, browse what's known
+list_knowledge({ project: "infer-monorepo", limit: 20 })
+
+# Read interesting items
+get_knowledge({ id: "..." })
+```

--- a/docs/mcp-config-template.md
+++ b/docs/mcp-config-template.md
@@ -1,0 +1,72 @@
+# MCP Config Template for Team Memory
+
+This document provides ready-to-use configuration snippets for connecting an agent to the Team Memory MCP server.
+
+## Prerequisites
+
+1. The Team Memory backend is running (default: `http://localhost:3456`)
+2. The MCP server package is built: `cd packages/mcp-server && npm install && npm run build`
+
+## Claude Code (claude_desktop_config.json)
+
+Add this entry to your `mcpServers` configuration:
+
+```json
+{
+  "mcpServers": {
+    "team-memory": {
+      "command": "node",
+      "args": ["/absolute/path/to/team-memory/packages/mcp-server/dist/index.js"],
+      "env": {
+        "TEAM_MEMORY_URL": "http://localhost:3456"
+      }
+    }
+  }
+}
+```
+
+Replace `/absolute/path/to/team-memory` with the actual path to your cloned repo.
+
+## Claude Code (project-scoped .mcp.json)
+
+Place this file at the root of your project as `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "team-memory": {
+      "command": "node",
+      "args": ["./packages/mcp-server/dist/index.js"],
+      "env": {
+        "TEAM_MEMORY_URL": "http://localhost:3456"
+      }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TEAM_MEMORY_URL` | `http://localhost:3456` | Backend API base URL |
+
+## Available Tools After Connection
+
+Once connected, your agent will have access to:
+
+| Tool | Purpose |
+|------|---------|
+| `publish_knowledge` | Share a finding with the team |
+| `query_knowledge` | Search knowledge by keywords (FTS5) |
+| `list_knowledge` | Browse knowledge by project/tags |
+| `get_knowledge` | Read full detail of a knowledge item |
+| `update_knowledge` | Update metadata (tags, confidence, staleness, related_to) |
+
+## Verification
+
+After configuring, verify the connection by asking your agent:
+
+> "List all knowledge items in the team-memory project."
+
+If the agent successfully calls `list_knowledge`, the integration is working.

--- a/docs/mcp-config-template.md
+++ b/docs/mcp-config-template.md
@@ -18,14 +18,15 @@ Add this entry to your `mcpServers` configuration:
       "command": "node",
       "args": ["/absolute/path/to/team-memory/packages/mcp-server/dist/index.js"],
       "env": {
-        "TEAM_MEMORY_URL": "http://localhost:3456"
+        "TEAM_MEMORY_URL": "http://localhost:3456",
+        "TEAM_MEMORY_API_KEY": "<your-api-key>"
       }
     }
   }
 }
 ```
 
-Replace `/absolute/path/to/team-memory` with the actual path to your cloned repo.
+Replace `/absolute/path/to/team-memory` with the actual path to your cloned repo, and `<your-api-key>` with the key generated for your agent (see M2 auth setup).
 
 ## Claude Code (project-scoped .mcp.json)
 
@@ -38,7 +39,8 @@ Place this file at the root of your project as `.mcp.json`:
       "command": "node",
       "args": ["./packages/mcp-server/dist/index.js"],
       "env": {
-        "TEAM_MEMORY_URL": "http://localhost:3456"
+        "TEAM_MEMORY_URL": "http://localhost:3456",
+        "TEAM_MEMORY_API_KEY": "<your-api-key>"
       }
     }
   }
@@ -50,6 +52,7 @@ Place this file at the root of your project as `.mcp.json`:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TEAM_MEMORY_URL` | `http://localhost:3456` | Backend API base URL |
+| `TEAM_MEMORY_API_KEY` | (none) | API key for authentication. Owner is derived from the key. Required once M2 auth is enabled. |
 
 ## Available Tools After Connection
 

--- a/docs/system-prompt-snippet.md
+++ b/docs/system-prompt-snippet.md
@@ -1,0 +1,47 @@
+# System Prompt Snippet for Team Memory
+
+Copy the section below into your agent's system prompt or CLAUDE.md to enable Team Memory integration.
+
+---
+
+## Snippet
+
+```markdown
+## Team Memory
+
+You have access to a shared team knowledge base via the Team Memory MCP tools. Use it to avoid duplicate work and share your findings.
+
+### Before starting a task
+
+1. Call `query_knowledge` with keywords related to your task and the project name.
+2. If results are found, call `get_knowledge` to read the full detail.
+3. Use existing knowledge as context. Do not redo analysis that has already been published.
+
+### After completing a task
+
+If you discovered something reusable (architectural insight, verified behavior, non-obvious finding), publish it:
+
+- Call `publish_knowledge` with a single, falsifiable claim.
+- Set `confidence` based on your verification level: `high` (tested/traced), `medium` (read code), `low` (inferred).
+- Set `staleness_hint` to describe when this knowledge should be re-verified.
+- If your finding contradicts an existing item, use `supersedes` to link to the old item.
+
+### Rules
+
+- One claim per knowledge item. Multiple findings = multiple publishes.
+- Do not publish ephemeral status, obvious facts, or conversation summaries.
+- Use `update_knowledge` only for metadata changes (tags, confidence, staleness_hint, related_to), never to change the claim itself.
+- When superseding, always publish a new item rather than editing the old one.
+```
+
+---
+
+## Usage
+
+**For Claude Code agents (CLAUDE.md):**
+
+Add the snippet above to your project's `CLAUDE.md` file. Claude Code reads this file automatically at the start of each session.
+
+**For other agent frameworks:**
+
+Append the snippet to your agent's system prompt or instruction set. Ensure the Team Memory MCP server is configured in the agent's tool list (see `docs/mcp-config-template.md`).

--- a/docs/system-prompt-snippet.md
+++ b/docs/system-prompt-snippet.md
@@ -22,6 +22,7 @@ You have access to a shared team knowledge base via the Team Memory MCP tools. U
 If you discovered something reusable (architectural insight, verified behavior, non-obvious finding), publish it:
 
 - Call `publish_knowledge` with a single, falsifiable claim.
+- Your `owner` identity is automatically set from your API key — do not pass it manually.
 - Set `confidence` based on your verification level: `high` (tested/traced), `medium` (read code), `low` (inferred).
 - Set `staleness_hint` to describe when this knowledge should be re-verified.
 - If your finding contradicts an existing item, use `supersedes` to link to the old item.


### PR DESCRIPTION
## Summary
- `docs/agent-protocol.md` — defines the query-before-work, publish-after-work agent workflow, claim writing guidelines, confidence/staleness standards, and supersedes usage
- `docs/system-prompt-snippet.md` — copy-paste snippet for CLAUDE.md or agent system prompts
- `docs/mcp-config-template.md` — ready-to-use MCP server config for Claude Code (desktop and project-scoped)

## Context
Phase 2 / M3 (Task #19). These docs define the standard agent behavior for Team Memory integration. They are prerequisites for M5 (Team Pilot) where all 6 agents will onboard.

## Test plan
- [ ] Review protocol rules for completeness and clarity
- [ ] Verify MCP config template works with a real Claude Code setup
- [ ] Confirm system prompt snippet is self-contained and copy-paste ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)