### PR TITLE
Phase 2: add backend auth and quality foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,17 @@ jobs:
           echo "Backend failed to start"
           exit 1
 
+      - name: Create E2E API key
+        id: apikey
+        working-directory: packages/backend
+        run: |
+          OUTPUT=$(npx tsx src/cli.ts create e2e-test)
+          KEY=$(echo "$OUTPUT" | grep '^key=' | cut -d= -f2)
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
       - name: Run E2E HTTP tests
         working-directory: e2e/scripts
         run: node team-memory-e2e-http-demo.mjs
         env:
           TEAM_MEMORY_BASE_URL: http://localhost:3456/api
+          TEAM_MEMORY_API_KEY: ${{ steps.apikey.outputs.key }}

--- a/e2e/scripts/team-memory-e2e-http-demo.mjs
+++ b/e2e/scripts/team-memory-e2e-http-demo.mjs
@@ -1,4 +1,5 @@
 const baseUrl = process.env.TEAM_MEMORY_BASE_URL || "http://localhost:3456/api";
+const apiKey = process.env.TEAM_MEMORY_API_KEY;
 
 function fail(message) {
   console.error(`FAIL: ${message}`);
@@ -30,6 +31,10 @@ async function requestJson(url, options = {}) {
 }
 
 async function main() {
+  if (!apiKey) {
+    fail("TEAM_MEMORY_API_KEY is required for authenticated publish");
+  }
+
   const payload = {
     claim: "infer-monorepo's primary architecture axis is DEPLOY_MODE rather than folder structure.",
     detail:
@@ -43,7 +48,6 @@ async function main() {
     tags: ["architecture", "deploy-mode"],
     confidence: "high",
     staleness_hint: "Recheck if deploy-mode logic or package boundaries change.",
-    owner: "AgentA",
     related_to: [],
   };
 
@@ -51,6 +55,9 @@ async function main() {
 
   const created = await requestJson(`${baseUrl}/knowledge`, {
     method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+    },
     body: JSON.stringify(payload),
   });
 
@@ -91,6 +98,9 @@ async function main() {
     "updated_at",
   ]) {
     if (!(field in full)) fail(`full item missing field ${field}`);
+  }
+  for (const field of ["is_stale", "stale_after_days", "stale_at", "effective_confidence"]) {
+    if (!(field in full)) fail(`full item missing quality field ${field}`);
   }
 
   if (!Array.isArray(full.source) || full.source.length === 0) {

--- a/e2e/scripts/team-memory-mcp-smoke.mjs
+++ b/e2e/scripts/team-memory-mcp-smoke.mjs
@@ -1,5 +1,5 @@
-import { Client } from "../team-memory-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js";
-import { StdioClientTransport } from "../team-memory-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js";
+import { Client } from "../../packages/mcp-server/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js";
+import { StdioClientTransport } from "../../packages/mcp-server/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js";
 
 function getText(result) {
   const first = result.content?.find((item) => item.type === "text");
@@ -13,6 +13,10 @@ function fail(message) {
 
 async function main() {
   const backendUrl = process.env.TEAM_MEMORY_URL || "http://localhost:3456";
+  const apiKey = process.env.TEAM_MEMORY_API_KEY;
+  if (!apiKey) {
+    fail("TEAM_MEMORY_API_KEY is required for authenticated MCP smoke tests");
+  }
   const client = new Client(
     { name: "team-memory-e2e-smoke", version: "0.1.0" },
     { capabilities: {} },
@@ -21,10 +25,11 @@ async function main() {
   const transport = new StdioClientTransport({
     command: "node",
     args: ["dist/index.js"],
-    cwd: new URL("../team-memory-mcp/", import.meta.url).pathname,
+    cwd: new URL("../../packages/mcp-server/", import.meta.url).pathname,
     env: {
       ...process.env,
       TEAM_MEMORY_URL: backendUrl,
+      TEAM_MEMORY_API_KEY: apiKey,
     },
     stderr: "pipe",
   });

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "keys": "tsx src/cli.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.14",

--- a/packages/backend/src/auth.ts
+++ b/packages/backend/src/auth.ts
@@ -1,0 +1,44 @@
+import type { Context } from "hono";
+import { getDb } from "./db.js";
+
+export interface ApiAuth {
+  key: string;
+  owner: string;
+}
+
+function jsonError(c: Context, status: 401 | 403, error: string, code: string): Response {
+  return c.json({ error, code }, status);
+}
+
+function extractBearerToken(header: string | undefined): string | null {
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+}
+
+export function requireApiAuth(c: Context): ApiAuth | Response {
+  const token = extractBearerToken(c.req.header("authorization"));
+  if (!token) {
+    return jsonError(c, 401, "Missing Authorization: Bearer <api_key> header", "auth_missing");
+  }
+
+  const db = getDb();
+  const row = db
+    .prepare("SELECT key, owner FROM api_keys WHERE key = ? AND revoked_at IS NULL")
+    .get(token) as ApiAuth | undefined;
+
+  if (!row) {
+    return jsonError(c, 401, "Invalid API key", "auth_invalid");
+  }
+
+  return row;
+}
+
+export function requireOwnerAccess(c: Context, itemOwner: string): ApiAuth | Response {
+  const auth = requireApiAuth(c);
+  if (auth instanceof Response) return auth;
+  if (auth.owner !== itemOwner) {
+    return jsonError(c, 403, "Only the owner can modify this item", "owner_forbidden");
+  }
+  return auth;
+}

--- a/packages/backend/src/cli.ts
+++ b/packages/backend/src/cli.ts
@@ -1,0 +1,81 @@
+import { randomBytes } from "node:crypto";
+import { closeDb, getDb } from "./db.js";
+
+function usage(): never {
+  console.error(`Usage:
+  npm run keys -- create <owner>
+  npm run keys -- list
+  npm run keys -- revoke <api_key>`);
+  process.exit(1);
+}
+
+function createKey(owner: string): void {
+  const db = getDb();
+  const key = `tm_${randomBytes(24).toString("hex")}`;
+  const createdAt = new Date().toISOString();
+
+  db.prepare("INSERT INTO api_keys (key, owner, created_at, revoked_at) VALUES (?, ?, ?, NULL)").run(
+    key,
+    owner,
+    createdAt,
+  );
+
+  console.log(`Created API key for ${owner}`);
+  console.log(`key=${key}`);
+  console.log(`created_at=${createdAt}`);
+}
+
+function listKeys(): void {
+  const db = getDb();
+  const rows = db
+    .prepare("SELECT key, owner, created_at, revoked_at FROM api_keys ORDER BY created_at DESC")
+    .all() as Array<{ key: string; owner: string; created_at: string; revoked_at: string | null }>;
+
+  if (rows.length === 0) {
+    console.log("No API keys found.");
+    return;
+  }
+
+  for (const row of rows) {
+    console.log(
+      `${row.key} owner=${row.owner} created_at=${row.created_at} status=${row.revoked_at ? "revoked" : "active"}`,
+    );
+  }
+}
+
+function revokeKey(key: string): void {
+  const db = getDb();
+  const revokedAt = new Date().toISOString();
+  const result = db
+    .prepare("UPDATE api_keys SET revoked_at = ? WHERE key = ? AND revoked_at IS NULL")
+    .run(revokedAt, key);
+
+  if (result.changes === 0) {
+    console.error(`No active API key found for ${key}`);
+    process.exit(1);
+  }
+
+  console.log(`Revoked API key ${key}`);
+}
+
+try {
+  const [command, arg] = process.argv.slice(2);
+
+  switch (command) {
+    case "create":
+      if (!arg) usage();
+      createKey(arg);
+      break;
+    case "list":
+      listKeys();
+      break;
+    case "revoke":
+      if (!arg) usage();
+      revokeKey(arg);
+      break;
+    default:
+      usage();
+  }
+} finally {
+  closeDb();
+}

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -5,6 +5,17 @@ const DB_PATH = process.env.TEAM_MEMORY_DB ?? path.join(process.cwd(), "team-mem
 
 let _db: Database.Database | null = null;
 
+function hasColumn(db: Database.Database, table: string, column: string): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === column);
+}
+
+function ensureColumn(db: Database.Database, table: string, column: string, definition: string): void {
+  if (!hasColumn(db, table, column)) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+  }
+}
+
 export function getDb(): Database.Database {
   if (_db) return _db;
 
@@ -34,6 +45,7 @@ export function getDb(): Database.Database {
     CREATE INDEX IF NOT EXISTS idx_knowledge_project ON knowledge(project);
     CREATE INDEX IF NOT EXISTS idx_knowledge_owner ON knowledge(owner);
     CREATE INDEX IF NOT EXISTS idx_knowledge_created ON knowledge(created_at);
+    CREATE INDEX IF NOT EXISTS idx_knowledge_superseded_by ON knowledge(superseded_by);
 
     CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
       claim, detail, tags,
@@ -56,7 +68,20 @@ export function getDb(): Database.Database {
       INSERT INTO knowledge_fts(rowid, claim, detail, tags)
       VALUES (new.rowid, new.claim, new.detail, new.tags);
     END;
+
+    CREATE TABLE IF NOT EXISTS api_keys (
+      key         TEXT PRIMARY KEY,
+      owner       TEXT NOT NULL,
+      created_at  TEXT NOT NULL,
+      revoked_at  TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(owner);
+    CREATE INDEX IF NOT EXISTS idx_api_keys_revoked_at ON api_keys(revoked_at);
   `);
+
+  ensureColumn(_db, "knowledge", "duplicate_of", "TEXT");
+  _db.exec("CREATE INDEX IF NOT EXISTS idx_knowledge_duplicate_of ON knowledge(duplicate_of)");
 
   return _db;
 }

--- a/packages/backend/src/quality.ts
+++ b/packages/backend/src/quality.ts
@@ -1,0 +1,145 @@
+import type Database from "better-sqlite3";
+
+const CONFIDENCE_ORDER = ["low", "medium", "high"] as const;
+type Confidence = (typeof CONFIDENCE_ORDER)[number];
+
+export interface QualityFlags {
+  is_stale: boolean;
+  stale_after_days: number;
+  stale_at: string;
+  effective_confidence: Confidence;
+}
+
+interface QualityRow {
+  confidence: string;
+  updated_at: string;
+}
+
+interface DuplicateRow {
+  id: string;
+  claim: string;
+  project: string;
+  module: string | null;
+  tags: string;
+  confidence: string;
+  staleness_hint: string;
+  owner: string;
+  created_at: string;
+}
+
+export interface DuplicateSummary {
+  id: string;
+  claim: string;
+  project: string;
+  module: string | null;
+  tags: string[];
+  confidence: string;
+  staleness_hint: string;
+  owner: string;
+  created_at: string;
+}
+
+function normalizeConfidence(value: string): Confidence {
+  return CONFIDENCE_ORDER.includes(value as Confidence) ? (value as Confidence) : "low";
+}
+
+function lowerConfidence(value: Confidence): Confidence {
+  const index = CONFIDENCE_ORDER.indexOf(value);
+  return CONFIDENCE_ORDER[Math.max(0, index - 1)];
+}
+
+function staleAfterDays(): number {
+  const raw = Number.parseInt(process.env.TEAM_MEMORY_STALE_AFTER_DAYS ?? "30", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 30;
+}
+
+export function qualityFlagsFromRow(row: QualityRow): QualityFlags {
+  const days = staleAfterDays();
+  const base = new Date(row.updated_at);
+  const staleAtMs = base.getTime() + days * 24 * 60 * 60 * 1000;
+  const isStale = staleAtMs <= Date.now();
+  const confidence = normalizeConfidence(row.confidence);
+
+  return {
+    is_stale: isStale,
+    stale_after_days: days,
+    stale_at: new Date(staleAtMs).toISOString(),
+    effective_confidence: isStale ? lowerConfidence(confidence) : confidence,
+  };
+}
+
+function tokenize(text: string): string[] {
+  return Array.from(
+    new Set(
+      text
+        .toLowerCase()
+        .split(/[^a-z0-9_]+/g)
+        .map((part) => part.trim())
+        .filter((part) => part.length >= 3),
+    ),
+  ).slice(0, 8);
+}
+
+function rowToDuplicateSummary(row: DuplicateRow): DuplicateSummary {
+  return {
+    id: row.id,
+    claim: row.claim,
+    project: row.project,
+    module: row.module,
+    tags: JSON.parse(row.tags) as string[],
+    confidence: row.confidence,
+    staleness_hint: row.staleness_hint,
+    owner: row.owner,
+    created_at: row.created_at,
+  };
+}
+
+export function detectPossibleDuplicates(
+  db: Database.Database,
+  input: { claim: string; project: string; excludeId?: string | null },
+): DuplicateSummary[] {
+  const seen = new Set<string>();
+  const matches: DuplicateSummary[] = [];
+  const excludeId = input.excludeId ?? null;
+
+  const exactRows = db.prepare(
+    `SELECT id, claim, project, module, tags, confidence, staleness_hint, owner, created_at
+     FROM knowledge
+     WHERE lower(claim) = lower(?)
+       AND project = ?
+       AND superseded_by IS NULL
+       AND (? IS NULL OR id != ?)
+     ORDER BY created_at DESC
+     LIMIT 3`,
+  ).all(input.claim, input.project, excludeId, excludeId) as DuplicateRow[];
+
+  for (const row of exactRows) {
+    seen.add(row.id);
+    matches.push(rowToDuplicateSummary(row));
+  }
+
+  const terms = tokenize(input.claim);
+  if (terms.length === 0) return matches;
+
+  const query = terms.join(" OR ");
+  const ftsRows = db.prepare(
+    `SELECT k.id, k.claim, k.project, k.module, k.tags, k.confidence, k.staleness_hint, k.owner, k.created_at
+     FROM knowledge_fts fts
+     JOIN knowledge k ON k.rowid = fts.rowid
+     WHERE knowledge_fts MATCH ?
+       AND k.project = ?
+       AND k.superseded_by IS NULL
+       AND (? IS NULL OR k.id != ?)
+     ORDER BY rank
+     LIMIT 5`,
+  ).all(query, input.project, excludeId, excludeId) as DuplicateRow[];
+
+  for (const row of ftsRows) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    matches.push(rowToDuplicateSummary(row));
+    if (matches.length >= 3) break;
+  }
+
+  return matches;
+}

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { v4 as uuidv4 } from "uuid";
+import { requireApiAuth, requireOwnerAccess } from "./auth.js";
 import { getDb } from "./db.js";
+import { detectPossibleDuplicates, qualityFlagsFromRow } from "./quality.js";
 
 const api = new Hono();
 
@@ -8,7 +10,7 @@ interface KnowledgeRow {
   id: string; claim: string; detail: string | null; source: string;
   project: string; module: string | null; tags: string; confidence: string;
   staleness_hint: string; owner: string; related_to: string;
-  supersedes: string | null; superseded_by: string | null;
+  supersedes: string | null; superseded_by: string | null; duplicate_of: string | null;
   created_at: string; updated_at: string;
 }
 
@@ -19,8 +21,9 @@ function rowToJson(row: KnowledgeRow) {
     tags: JSON.parse(row.tags), confidence: row.confidence,
     staleness_hint: row.staleness_hint, owner: row.owner,
     related_to: JSON.parse(row.related_to), supersedes: row.supersedes,
-    superseded_by: row.superseded_by, created_at: row.created_at,
-    updated_at: row.updated_at,
+    superseded_by: row.superseded_by, duplicate_of: row.duplicate_of,
+    created_at: row.created_at, updated_at: row.updated_at,
+    ...qualityFlagsFromRow(row),
   };
 }
 
@@ -29,7 +32,8 @@ function summaryFromRow(row: KnowledgeRow) {
     id: row.id, claim: row.claim, project: row.project, module: row.module,
     tags: JSON.parse(row.tags), confidence: row.confidence,
     staleness_hint: row.staleness_hint, owner: row.owner,
-    created_at: row.created_at,
+    duplicate_of: row.duplicate_of, created_at: row.created_at,
+    ...qualityFlagsFromRow(row),
   };
 }
 
@@ -37,19 +41,24 @@ const VALID_CONFIDENCE = new Set(["high", "medium", "low"]);
 
 // 1. POST /api/knowledge
 api.post("/knowledge", async (c) => {
+  const auth = requireApiAuth(c);
+  if (auth instanceof Response) return auth;
+
   const body = await c.req.json();
   const missing: string[] = [];
-  for (const f of ["claim", "source", "project", "tags", "confidence", "staleness_hint", "owner"]) {
+  for (const f of ["claim", "source", "project", "tags", "confidence", "staleness_hint"]) {
     if (body[f] === undefined || body[f] === null || body[f] === "") missing.push(f);
   }
   if (missing.length > 0) return c.json({ error: `Missing required fields: ${missing.join(", ")}` }, 400);
   if (!Array.isArray(body.source) || body.source.length === 0) return c.json({ error: "source must be a non-empty array of strings" }, 400);
-  if (!Array.isArray(body.tags)) return c.json({ error: "tags must be an array of strings" }, 400);
+  if (!Array.isArray(body.tags) || body.tags.length === 0) return c.json({ error: "tags must be a non-empty array of strings" }, 400);
   if (!VALID_CONFIDENCE.has(body.confidence)) return c.json({ error: "confidence must be one of: high, medium, low" }, 400);
 
   const db = getDb();
   const id = uuidv4();
   const now = new Date().toISOString();
+  const duplicates = detectPossibleDuplicates(db, { claim: body.claim, project: body.project });
+  const duplicateOf = duplicates[0]?.id ?? null;
 
   if (body.supersedes) {
     const old = db.prepare("SELECT id, superseded_by FROM knowledge WHERE id = ?").get(body.supersedes) as { id: string; superseded_by: string | null } | undefined;
@@ -64,16 +73,24 @@ api.post("/knowledge", async (c) => {
     }
   }
 
-  const insert = db.prepare(`INSERT INTO knowledge (id, claim, detail, source, project, module, tags, confidence, staleness_hint, owner, related_to, supersedes, superseded_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)`);
+  const insert = db.prepare(`INSERT INTO knowledge (id, claim, detail, source, project, module, tags, confidence, staleness_hint, owner, related_to, supersedes, superseded_by, duplicate_of, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)`);
   const updateSuperseded = db.prepare("UPDATE knowledge SET superseded_by = ? WHERE id = ?");
 
   db.transaction(() => {
-    insert.run(id, body.claim, body.detail ?? null, JSON.stringify(body.source), body.project, body.module ?? null, JSON.stringify(body.tags), body.confidence, body.staleness_hint, body.owner, JSON.stringify(body.related_to ?? []), body.supersedes ?? null, now, now);
+    insert.run(id, body.claim, body.detail ?? null, JSON.stringify(body.source), body.project, body.module ?? null, JSON.stringify(body.tags), body.confidence, body.staleness_hint, auth.owner, JSON.stringify(body.related_to ?? []), body.supersedes ?? null, duplicateOf, now, now);
     if (body.supersedes) updateSuperseded.run(id, body.supersedes);
   })();
 
   const row = db.prepare("SELECT * FROM knowledge WHERE id = ?").get(id) as KnowledgeRow;
-  return c.json(rowToJson(row), 201);
+  const responseBody = rowToJson(row);
+  const warnings = duplicates.length > 0
+    ? [{
+        code: "possible_duplicate",
+        message: `Found ${duplicates.length} possible duplicate knowledge item(s) in project ${body.project}`,
+        matches: duplicates,
+      }]
+    : [];
+  return c.json({ ...responseBody, warnings }, 201);
 });
 
 // 2. GET /api/knowledge/search
@@ -144,6 +161,8 @@ api.patch("/knowledge/:id", async (c) => {
   const db = getDb();
   const row = db.prepare("SELECT * FROM knowledge WHERE id = ?").get(id) as KnowledgeRow | undefined;
   if (!row) return c.json({ error: "Knowledge item not found" }, 404);
+  const auth = requireOwnerAccess(c, row.owner);
+  if (auth instanceof Response) return auth;
   const immutable = ["claim", "detail", "source", "project", "module", "owner"];
   const attempted = immutable.filter((f) => body[f] !== undefined);
   if (attempted.length > 0) return c.json({ error: `Cannot modify immutable fields: ${attempted.join(", ")}` }, 400);


### PR DESCRIPTION
## Summary
- add backend API key auth for write operations with owner attribution and owner-only PATCH
- add backend key-management CLI and DB support for API keys
- add quality foundations: stale flags/effective confidence plus duplicate warnings on publish
- update E2E scripts toward the Phase 2 auth model and fix the repo MCP smoke path

## Included for #17
- `api_keys` table (`key`, `owner`, `created_at`, `revoked_at`)
- Bearer auth on write endpoints
- `POST /api/knowledge` derives `owner` from API key
- `PATCH /api/knowledge/:id` enforces owner-only mutation
- `npm run keys -- create|list|revoke`

## Included for #20 (backend half)
- computed quality fields on knowledge responses:
  - `is_stale`
  - `stale_after_days`
  - `stale_at`
  - `effective_confidence`
  - `duplicate_of`
- publish-time duplicate warning via FTS5-backed lookup (`warnings[]` in POST response)

## Auth Contract For Clients
- write endpoints require `Authorization: Bearer <api_key>`
- read endpoints remain anonymous for now
- `POST /api/knowledge` no longer needs a trusted client-side `owner`; backend fills it from the key
- auth error codes:
  - `401 auth_missing`
  - `401 auth_invalid`
  - `403 owner_forbidden`

## Manual Validation
- `npm run build` in `packages/backend`
- CLI key creation for `Ein` and `Other`
- verified:
  - unauthenticated POST -> `401 auth_missing`
  - authenticated POST auto-fills `owner`
  - non-owner PATCH -> `403 owner_forbidden`
  - duplicate publish returns `warnings[0].code = possible_duplicate`
  - stale item read returns `is_stale=true` and downgraded `effective_confidence`
- updated HTTP E2E script also ran successfully against the auth-enabled backend

## Coordination Notes
- @Ed already has the auth contract and is adapting the MCP server + dashboard in parallel for #18
- the MCP smoke script now forwards `TEAM_MEMORY_API_KEY` and points at `packages/mcp-server`
