### PR TITLE
feat: API key auth support for MCP Server + Dashboard (#18)

### DIFF
--- a/packages/dashboard/src/App.css
+++ b/packages/dashboard/src/App.css
@@ -28,6 +28,64 @@
   margin-left: auto;
 }
 
+.settings-btn {
+  border: none;
+  background: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.settings-btn:hover {
+  background: var(--accent-bg);
+}
+
+.settings-bar {
+  padding: 10px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--bg-secondary);
+  font-size: 13px;
+}
+
+.settings-bar label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.settings-bar input {
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: var(--mono);
+  background: var(--bg);
+  color: var(--text);
+  width: 300px;
+}
+
+.settings-bar button {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.settings-bar button:hover {
+  background: var(--accent-bg);
+}
+
 .app-body {
   display: flex;
   flex: 1;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -5,6 +5,8 @@ import {
   searchKnowledge,
   getKnowledge,
   getAllFilters,
+  getApiKey,
+  setApiKey,
 } from "./api";
 import "./App.css";
 
@@ -20,6 +22,8 @@ function App() {
   const [projects, setProjects] = useState<string[]>([]);
   const [owners, setOwners] = useState<string[]>([]);
   const [tags, setTags] = useState<string[]>([]);
+  const [showSettings, setShowSettings] = useState(false);
+  const [apiKeyInput, setApiKeyInput] = useState(getApiKey() ?? "");
 
   useEffect(() => {
     getAllFilters().then(({ projects, owners, tags }) => {
@@ -71,7 +75,47 @@ function App() {
         <span className="stats">
           {total} knowledge item{total !== 1 ? "s" : ""}
         </span>
+        <button
+          className="settings-btn"
+          onClick={() => setShowSettings(!showSettings)}
+          title="API Key Settings"
+        >
+          {getApiKey() ? "🔑" : "⚙"}
+        </button>
       </header>
+
+      {showSettings && (
+        <div className="settings-bar">
+          <label>
+            API Key:
+            <input
+              type="password"
+              value={apiKeyInput}
+              onChange={(e) => setApiKeyInput(e.target.value)}
+              placeholder="Enter API key for write operations"
+            />
+          </label>
+          <button
+            onClick={() => {
+              setApiKey(apiKeyInput || null);
+              setShowSettings(false);
+            }}
+          >
+            Save
+          </button>
+          {getApiKey() && (
+            <button
+              onClick={() => {
+                setApiKey(null);
+                setApiKeyInput("");
+                setShowSettings(false);
+              }}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
 
       <div className="app-body">
         <aside className="sidebar">

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -4,6 +4,28 @@ import { mockKnowledge } from "./mockData";
 const API_BASE = "http://localhost:3457/api";
 const USE_MOCK = false;
 
+let _apiKey: string | null = localStorage.getItem("tm_api_key");
+
+export function setApiKey(key: string | null) {
+  _apiKey = key;
+  if (key) {
+    localStorage.setItem("tm_api_key", key);
+  } else {
+    localStorage.removeItem("tm_api_key");
+  }
+}
+
+export function getApiKey(): string | null {
+  return _apiKey;
+}
+
+function authHeaders(): Record<string, string> {
+  if (_apiKey) {
+    return { Authorization: `Bearer ${_apiKey}` };
+  }
+  return {};
+}
+
 interface ListParams {
   project?: string;
   tags?: string;

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -147,7 +147,7 @@ async function fetchList(params: ListParams): Promise<PaginatedResponse<Knowledg
   if (params.include_superseded) url.searchParams.set("include_superseded", "true");
   if (params.limit) url.searchParams.set("limit", String(params.limit));
   if (params.offset) url.searchParams.set("offset", String(params.offset));
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: authHeaders() });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }
@@ -160,13 +160,13 @@ async function fetchSearch(params: SearchParams): Promise<PaginatedResponse<Know
   if (params.module) url.searchParams.set("module", params.module);
   if (params.include_superseded) url.searchParams.set("include_superseded", "true");
   if (params.limit) url.searchParams.set("limit", String(params.limit));
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: authHeaders() });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }
 
 async function fetchGet(id: string): Promise<KnowledgeItem | null> {
-  const res = await fetch(`${API_BASE}/knowledge/${encodeURIComponent(id)}`);
+  const res = await fetch(`${API_BASE}/knowledge/${encodeURIComponent(id)}`, { headers: authHeaders() });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -19,7 +19,7 @@ export function getApiKey(): string | null {
   return _apiKey;
 }
 
-function authHeaders(): Record<string, string> {
+export function authHeaders(): Record<string, string> {
   if (_apiKey) {
     return { Authorization: `Bearer ${_apiKey}` };
   }

--- a/packages/mcp-server/src/api-client.ts
+++ b/packages/mcp-server/src/api-client.ts
@@ -42,7 +42,7 @@ export interface PublishInput {
   tags: string[];
   confidence: "high" | "medium" | "low";
   staleness_hint: string;
-  owner: string;
+  owner?: string;
   related_to?: string[];
   supersedes?: string;
 }
@@ -71,15 +71,25 @@ export interface UpdateInput {
 
 export class ApiClient {
   private baseUrl: string;
+  private apiKey?: string;
 
-  constructor(baseUrl: string) {
+  constructor(baseUrl: string, apiKey?: string) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.apiKey = apiKey;
+  }
+
+  private writeHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    return headers;
   }
 
   async publish(input: PublishInput): Promise<KnowledgeItem> {
     const res = await fetch(`${this.baseUrl}/api/knowledge`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.writeHeaders(),
       body: JSON.stringify(input),
     });
     if (!res.ok) {
@@ -138,7 +148,7 @@ export class ApiClient {
     const { id, ...fields } = input;
     const res = await fetch(`${this.baseUrl}/api/knowledge/${id}`, {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
+      headers: this.writeHeaders(),
       body: JSON.stringify(fields),
     });
     if (!res.ok) {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,8 +6,9 @@ import { z } from "zod";
 import { ApiClient } from "./api-client.js";
 
 const BACKEND_URL = process.env.TEAM_MEMORY_URL ?? "http://localhost:3456";
+const API_KEY = process.env.TEAM_MEMORY_API_KEY;
 
-const client = new ApiClient(BACKEND_URL);
+const client = new ApiClient(BACKEND_URL, API_KEY);
 const server = new McpServer({
   name: "team-memory",
   version: "0.1.0",
@@ -26,7 +27,7 @@ server.tool(
     tags: z.array(z.string()).min(1).describe("Domain tags, e.g. ['architecture', 'billing'] (required, at least one)"),
     confidence: z.enum(["high", "medium", "low"]).describe("How confident you are in this claim (required)"),
     staleness_hint: z.string().describe("Under what conditions this knowledge may become stale (required)"),
-    owner: z.string().describe("Your agent name (required)"),
+    owner: z.string().optional().describe("Your agent name (auto-filled from API key if configured)"),
     related_to: z.array(z.string()).optional().describe("IDs of related knowledge items (optional)"),
     supersedes: z.string().optional().describe("ID of an older knowledge item this one replaces (optional)"),
   },


### PR DESCRIPTION
## Summary
- **MCP Server**: `ApiClient` now accepts optional `apiKey` (via `TEAM_MEMORY_API_KEY` env var), sends `Authorization: Bearer` header on POST/PATCH requests. `publish_knowledge` tool `owner` param is now optional since backend auto-fills from key.
- **Dashboard**: API key settings UI in header bar, key persisted in localStorage. `authHeaders()` helper ready for future write operations.

## Depends on
- #5 (M2 auth backend by @Ein) — this PR adapts clients to that auth contract

## Changes
- `packages/mcp-server/src/api-client.ts` — add `apiKey` constructor param, `writeHeaders()` method
- `packages/mcp-server/src/index.ts` — read `TEAM_MEMORY_API_KEY` env var, make `owner` optional
- `packages/dashboard/src/api.ts` — add `setApiKey()`/`getApiKey()`/`authHeaders()` helpers
- `packages/dashboard/src/App.tsx` — settings button + API key input UI
- `packages/dashboard/src/App.css` — settings bar styles

## Test plan
- [ ] MCP Server: verify `Authorization: Bearer` header sent on publish/update when `TEAM_MEMORY_API_KEY` set
- [ ] MCP Server: verify works without key (backward compatible)
- [ ] Dashboard: verify settings UI shows/hides, key persists in localStorage
- [ ] TypeScript: both packages pass `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)