### PR TITLE
feat(dashboard): stale/duplicate quality indicators

### DIFF
--- a/packages/dashboard/src/App.css
+++ b/packages/dashboard/src/App.css
@@ -353,6 +353,77 @@
   background: var(--accent-bg);
 }
 
+/* Quality badges */
+.quality-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.stale-badge {
+  background: var(--stale-bg);
+  color: var(--stale-text);
+  border: 1px solid var(--stale-border);
+}
+
+.duplicate-badge {
+  background: var(--duplicate-bg);
+  color: var(--duplicate-text);
+  border: 1px solid var(--duplicate-border);
+}
+
+/* Stale/duplicate row highlights */
+.knowledge-row.stale {
+  border-left: 3px solid var(--stale-text);
+  padding-left: 17px;
+}
+
+.knowledge-row.stale.selected {
+  border-left: 3px solid var(--accent);
+}
+
+.knowledge-row.duplicate {
+  opacity: 0.75;
+}
+
+/* Quality warnings in detail panel */
+.quality-warnings {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.quality-warning {
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.stale-warning {
+  background: var(--stale-bg);
+  border: 1px solid var(--stale-border);
+  color: var(--stale-text);
+}
+
+.duplicate-warning {
+  background: var(--duplicate-bg);
+  border: 1px solid var(--duplicate-border);
+  color: var(--duplicate-text);
+}
+
+.confidence-original {
+  font-weight: 400;
+  font-size: 10px;
+  opacity: 0.7;
+}
+
 /* Empty state */
 .empty-state {
   display: flex;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -175,13 +175,21 @@ function App() {
                   key={item.id}
                   className={`knowledge-row ${
                     selected?.id === item.id ? "selected" : ""
-                  }`}
+                  }${item.is_stale ? " stale" : ""}${item.duplicate_of ? " duplicate" : ""}`}
                   onClick={() => selectItem(item.id)}
                 >
-                  <div className="claim">{item.claim}</div>
+                  <div className="claim">
+                    {item.claim}
+                    {item.is_stale && (
+                      <span className="quality-badge stale-badge">stale</span>
+                    )}
+                    {item.duplicate_of && (
+                      <span className="quality-badge duplicate-badge">duplicate</span>
+                    )}
+                  </div>
                   <div className="meta">
-                    <span className={`confidence ${item.confidence}`}>
-                      {item.confidence}
+                    <span className={`confidence ${item.effective_confidence ?? item.confidence}`}>
+                      {item.effective_confidence ?? item.confidence}
                     </span>
                     <span>{item.project}</span>
                     {item.module && <span>/ {item.module}</span>}
@@ -257,7 +265,15 @@ function DetailView({
 }) {
   return (
     <div className="detail-content">
-      <h2>{item.claim}</h2>
+      <h2>
+        {item.claim}
+        {item.is_stale && (
+          <span className="quality-badge stale-badge">stale</span>
+        )}
+        {item.duplicate_of && (
+          <span className="quality-badge duplicate-badge">duplicate</span>
+        )}
+      </h2>
 
       {item.detail && (
         <div className="detail-section">
@@ -266,12 +282,40 @@ function DetailView({
         </div>
       )}
 
+      {(item.is_stale || item.duplicate_of) && (
+        <div className="detail-section quality-warnings">
+          {item.is_stale && (
+            <div className="quality-warning stale-warning">
+              This knowledge item is stale — it was last updated more than {item.stale_after_days ?? 30} days ago.
+              {item.stale_at && <> Stale since {formatDate(item.stale_at)}.</>}
+              {item.effective_confidence && item.effective_confidence !== item.confidence && (
+                <> Effective confidence downgraded from {item.confidence} to {item.effective_confidence}.</>
+              )}
+            </div>
+          )}
+          {item.duplicate_of && (
+            <div className="quality-warning duplicate-warning">
+              Possible duplicate of{" "}
+              <span
+                className="related-id"
+                onClick={() => onNavigate(item.duplicate_of!)}
+              >
+                {item.duplicate_of}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="detail-section">
         <div className="detail-meta">
           <div className="detail-meta-item">
             <span className="label">Confidence</span>
-            <span className={`confidence ${item.confidence}`}>
-              {item.confidence}
+            <span className={`confidence ${item.effective_confidence ?? item.confidence}`}>
+              {item.effective_confidence ?? item.confidence}
+              {item.effective_confidence && item.effective_confidence !== item.confidence && (
+                <span className="confidence-original"> (was {item.confidence})</span>
+              )}
             </span>
           </div>
           <div className="detail-meta-item">

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -14,6 +14,12 @@
   --confidence-high: #16a34a;
   --confidence-medium: #ca8a04;
   --confidence-low: #dc2626;
+  --stale-bg: rgba(234, 179, 8, 0.1);
+  --stale-text: #b45309;
+  --stale-border: rgba(234, 179, 8, 0.3);
+  --duplicate-bg: rgba(239, 68, 68, 0.1);
+  --duplicate-text: #dc2626;
+  --duplicate-border: rgba(239, 68, 68, 0.3);
   --shadow:
     rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
 
@@ -47,6 +53,12 @@
     --confidence-high: #4ade80;
     --confidence-medium: #facc15;
     --confidence-low: #f87171;
+    --stale-bg: rgba(250, 204, 21, 0.15);
+    --stale-text: #fbbf24;
+    --stale-border: rgba(250, 204, 21, 0.3);
+    --duplicate-bg: rgba(248, 113, 113, 0.15);
+    --duplicate-text: #f87171;
+    --duplicate-border: rgba(248, 113, 113, 0.3);
     --shadow:
       rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
   }

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -12,6 +12,11 @@ export interface KnowledgeItem {
   related_to?: string[];
   supersedes?: string;
   superseded_by?: string;
+  duplicate_of?: string | null;
+  is_stale?: boolean;
+  stale_after_days?: number;
+  stale_at?: string;
+  effective_confidence?: "high" | "medium" | "low";
   created_at: string;
   updated_at?: string;
 }
@@ -25,5 +30,10 @@ export interface KnowledgeListItem {
   owner: string;
   project: string;
   module?: string;
+  duplicate_of?: string | null;
+  is_stale?: boolean;
+  stale_after_days?: number;
+  stale_at?: string;
+  effective_confidence?: "high" | "medium" | "low";
   created_at: string;
 }


### PR DESCRIPTION
## Summary
- Display **stale** and **duplicate** quality badges on knowledge items in list view and detail panel
- Show quality warning banners in detail view with context (stale duration, confidence downgrade, link to duplicate source)
- Use `effective_confidence` from backend instead of raw `confidence` — stale items show their downgraded level
- CSS variables for light/dark themes; stale rows get left accent border, duplicate rows reduced opacity

## Changes
- `types.ts` — added `is_stale`, `stale_after_days`, `stale_at`, `effective_confidence`, `duplicate_of` to both `KnowledgeItem` and `KnowledgeListItem`
- `App.tsx` — quality badges in list rows + detail header, warning banners in detail panel, effective confidence display
- `App.css` — styles for `.quality-badge`, `.stale-badge`, `.duplicate-badge`, `.quality-warning`, row highlights
- `index.css` — added `--stale-*` and `--duplicate-*` CSS variables for both light and dark themes

## Test plan
- [ ] Verify stale items show amber "stale" badge in list and detail view
- [ ] Verify duplicate items show red "duplicate" badge in list and detail view  
- [ ] Verify clicking duplicate_of ID in detail panel navigates to the referenced item
- [ ] Verify effective_confidence is shown instead of raw confidence; downgrade note appears when they differ
- [ ] Verify dark mode colors render correctly
- [ ] Verify no regressions on items without quality flags (fields are optional)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)