### PR TITLE
ci: add MCP smoke test to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,10 @@ jobs:
         env:
           TEAM_MEMORY_BASE_URL: http://localhost:3456/api
           TEAM_MEMORY_API_KEY: ${{ steps.apikey.outputs.key }}
+
+      - name: Run MCP smoke tests
+        working-directory: e2e/scripts
+        run: node team-memory-mcp-smoke.mjs
+        env:
+          TEAM_MEMORY_URL: http://localhost:3456
+          TEAM_MEMORY_API_KEY: ${{ steps.apikey.outputs.key }}

--- a/e2e/scripts/team-memory-mcp-smoke.mjs
+++ b/e2e/scripts/team-memory-mcp-smoke.mjs
@@ -1,5 +1,5 @@
-import { Client } from "../../packages/mcp-server/node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js";
-import { StdioClientTransport } from "../../packages/mcp-server/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 function getText(result) {
   const first = result.content?.find((item) => item.type === "text");


### PR DESCRIPTION
## Summary
- Add MCP smoke test (`team-memory-mcp-smoke.mjs`) to CI pipeline
- This test validates the full MCP auth chain: publish → query → get via MCP transport with API key
- Previously only the HTTP E2E test ran in CI; since agents connect through MCP, this ensures the actual auth flow they use is covered

## Context
M5 Team Pilot requires all agents to connect via MCP. This CI step ensures the MCP Server → Backend API auth path stays green.

## Test plan
- [ ] CI passes with the new MCP smoke test step
- [ ] Both E2E HTTP and MCP smoke tests complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)