### PR TITLE
fix: exact-match only duplicate_of persistence

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,7 +7,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "keys": "tsx src/cli.ts"
+    "keys": "tsx src/cli.ts",
+    "test": "node --import tsx --test tests/**/*.test.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.14",

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import path from "node:path";
+import { cleanupFalsePositiveDuplicateOf } from "./duplicates.js";
 
 const DB_PATH = process.env.TEAM_MEMORY_DB ?? path.join(process.cwd(), "team-memory.db");
 
@@ -82,6 +83,7 @@ export function getDb(): Database.Database {
 
   ensureColumn(_db, "knowledge", "duplicate_of", "TEXT");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_knowledge_duplicate_of ON knowledge(duplicate_of)");
+  cleanupFalsePositiveDuplicateOf(_db);
 
   return _db;
 }

--- a/packages/backend/src/duplicates.ts
+++ b/packages/backend/src/duplicates.ts
@@ -1,0 +1,79 @@
+import type Database from "better-sqlite3";
+
+interface DuplicateCandidate {
+  id: string;
+  claim: string;
+  project: string;
+}
+
+interface DuplicateLinkRow {
+  id: string;
+  claim: string;
+  project: string;
+  duplicate_of: string;
+  target_claim: string | null;
+  target_project: string | null;
+}
+
+export function normalizeClaimForDuplicateMatch(claim: string): string {
+  return claim.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function isExactDuplicateMatch(
+  currentClaim: string,
+  currentProject: string,
+  targetClaim: string | null,
+  targetProject: string | null,
+): boolean {
+  if (!targetClaim || !targetProject) return false;
+  return (
+    currentProject === targetProject &&
+    normalizeClaimForDuplicateMatch(currentClaim) === normalizeClaimForDuplicateMatch(targetClaim)
+  );
+}
+
+export function findPersistedDuplicateOf(
+  claim: string,
+  project: string,
+  candidates: DuplicateCandidate[],
+): string | null {
+  const match = candidates.find((candidate) =>
+    isExactDuplicateMatch(claim, project, candidate.claim, candidate.project),
+  );
+  return match?.id ?? null;
+}
+
+export function cleanupFalsePositiveDuplicateOf(db: Database.Database): number {
+  const rows = db.prepare(
+    `SELECT
+       current.id,
+       current.claim,
+       current.project,
+       current.duplicate_of,
+       target.claim AS target_claim,
+       target.project AS target_project
+     FROM knowledge current
+     LEFT JOIN knowledge target ON target.id = current.duplicate_of
+     WHERE current.duplicate_of IS NOT NULL`,
+  ).all() as DuplicateLinkRow[];
+
+  const invalidIds = rows
+    .filter((row) =>
+      !isExactDuplicateMatch(row.claim, row.project, row.target_claim, row.target_project),
+    )
+    .map((row) => row.id);
+
+  if (invalidIds.length === 0) {
+    return 0;
+  }
+
+  const clearDuplicateOf = db.prepare("UPDATE knowledge SET duplicate_of = NULL WHERE id = ?");
+  const cleanup = db.transaction((ids: string[]) => {
+    for (const id of ids) {
+      clearDuplicateOf.run(id);
+    }
+  });
+
+  cleanup(invalidIds);
+  return invalidIds.length;
+}

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { v4 as uuidv4 } from "uuid";
 import { requireApiAuth, requireOwnerAccess } from "./auth.js";
 import { getDb } from "./db.js";
+import { findPersistedDuplicateOf } from "./duplicates.js";
 import { detectPossibleDuplicates, qualityFlagsFromRow } from "./quality.js";
 
 const api = new Hono();
@@ -58,7 +59,7 @@ api.post("/knowledge", async (c) => {
   const id = uuidv4();
   const now = new Date().toISOString();
   const duplicates = detectPossibleDuplicates(db, { claim: body.claim, project: body.project });
-  const duplicateOf = duplicates[0]?.id ?? null;
+  const duplicateOf = findPersistedDuplicateOf(body.claim, body.project, duplicates);
 
   if (body.supersedes) {
     const old = db.prepare("SELECT id, superseded_by FROM knowledge WHERE id = ?").get(body.supersedes) as { id: string; superseded_by: string | null } | undefined;

--- a/packages/backend/tests/duplicate-of.test.ts
+++ b/packages/backend/tests/duplicate-of.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-duplicate-of-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+process.env.TEAM_MEMORY_STALE_AFTER_DAYS = "30";
+
+interface ApiKnowledgeItem {
+  id: string;
+  claim: string;
+  duplicate_of: string | null;
+  warnings?: Array<{
+    code: string;
+    matches: Array<{ id: string }>;
+  }>;
+}
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+before(async () => {
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+});
+
+afterEach(() => {
+  const db = getDb();
+  db.exec("DELETE FROM knowledge; DELETE FROM api_keys;");
+});
+
+after(() => {
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.TEAM_MEMORY_DB;
+  delete process.env.TEAM_MEMORY_STALE_AFTER_DAYS;
+});
+
+function createApiKey(owner = "Tester"): string {
+  const db = getDb();
+  const key = `${owner.toLowerCase()}-key`;
+  db.prepare(
+    "INSERT OR REPLACE INTO api_keys (key, owner, created_at, revoked_at) VALUES (?, ?, ?, NULL)",
+  ).run(key, owner, new Date().toISOString());
+  return key;
+}
+
+async function publishKnowledge(
+  apiKey: string,
+  overrides: Partial<Record<string, unknown>> = {},
+): Promise<ApiKnowledgeItem> {
+  const payload = {
+    claim: "Billing pipeline uses Redis Stream buffering between inference and control.",
+    detail: "Used for duplicate persistence tests.",
+    source: ["tests/duplicate-of.test.ts"],
+    project: "team-memory",
+    module: "quality",
+    tags: ["quality", "duplicate"],
+    confidence: "high",
+    staleness_hint: "Recheck if duplicate matching rules change.",
+    related_to: [],
+    ...overrides,
+  };
+
+  const response = await app.request("http://localhost/api/knowledge", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  assert.equal(response.status, 201);
+  return (await response.json()) as ApiKnowledgeItem;
+}
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    claim: string;
+    project?: string;
+    duplicateOf?: string | null;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim,
+    null,
+    JSON.stringify(["tests/duplicate-of.test.ts"]),
+    input.project ?? "team-memory",
+    "quality",
+    JSON.stringify(["quality"]),
+    "high",
+    "Recheck if duplicate matching rules change.",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    null,
+    input.duplicateOf ?? null,
+    now,
+    now,
+  );
+}
+
+test("fuzzy duplicate warnings do not persist duplicate_of", async () => {
+  const apiKey = createApiKey();
+
+  const original = await publishKnowledge(apiKey, {
+    claim: "Billing pipeline uses Redis Stream buffering between inference and control.",
+  });
+  const fuzzy = await publishKnowledge(apiKey, {
+    claim: "Billing pipeline routes usage through Redis buffering before control persistence.",
+  });
+
+  assert.equal(fuzzy.warnings?.[0]?.code, "possible_duplicate");
+  assert.equal(fuzzy.warnings?.[0]?.matches[0]?.id, original.id);
+  assert.equal(fuzzy.duplicate_of, null);
+
+  const stored = getDb()
+    .prepare("SELECT duplicate_of FROM knowledge WHERE id = ?")
+    .get(fuzzy.id) as { duplicate_of: string | null };
+  assert.equal(stored.duplicate_of, null);
+});
+
+test("normalized exact claim matches persist duplicate_of", async () => {
+  const apiKey = createApiKey();
+
+  const original = await publishKnowledge(apiKey, {
+    claim: "All PG writes MUST come from control plane only.",
+  });
+  const exactDuplicate = await publishKnowledge(apiKey, {
+    claim: "  all   pg writes must come from control plane only.  ",
+  });
+
+  assert.equal(exactDuplicate.duplicate_of, original.id);
+});
+
+test("database startup cleanup clears false-positive duplicate_of but preserves exact matches", () => {
+  const db = getDb();
+
+  insertKnowledgeRow(db, {
+    id: "target-row",
+    claim: "All PG writes MUST come from control plane only.",
+  });
+  insertKnowledgeRow(db, {
+    id: "legacy-fuzzy-row",
+    claim: "Billing pipeline routes usage through Redis buffering before control persistence.",
+    duplicateOf: "target-row",
+  });
+  insertKnowledgeRow(db, {
+    id: "legacy-exact-row",
+    claim: " all   pg writes must come from control plane only. ",
+    duplicateOf: "target-row",
+  });
+
+  closeDb();
+  const reopened = getDb();
+
+  const fuzzyRow = reopened
+    .prepare("SELECT duplicate_of FROM knowledge WHERE id = ?")
+    .get("legacy-fuzzy-row") as { duplicate_of: string | null };
+  const exactRow = reopened
+    .prepare("SELECT duplicate_of FROM knowledge WHERE id = ?")
+    .get("legacy-exact-row") as { duplicate_of: string | null };
+
+  assert.equal(fuzzyRow.duplicate_of, null);
+  assert.equal(exactRow.duplicate_of, "target-row");
+});


### PR DESCRIPTION
## Summary
- persist `duplicate_of` only when the new claim is an exact normalized match of an existing claim in the same project
- run a startup cleanup that clears legacy false-positive `duplicate_of` links while preserving true exact duplicates
- add backend regression tests for fuzzy warning-only behavior, normalized exact persistence, and cleanup behavior

## Test Plan
- npm run test --workspace=packages/backend
- npm run build --workspace=packages/backend

## Notes
- I intentionally did not change `detectPossibleDuplicates`; fuzzy matching still drives warnings only.
- The repo pre-commit hook currently fails on backend changes because lint-staged appends file paths to `tsc -p`; I verified this fix with direct test/build commands and kept that separate from this PR.