### PR TITLE
fix: wrap lint-staged tsc to prevent TS5042

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
       "eslint --fix"
     ],
     "packages/backend/**/*.ts": [
-      "npx tsc --noEmit -p packages/backend/tsconfig.json"
+      "bash -c 'npx tsc --noEmit -p packages/backend/tsconfig.json'"
     ],
     "packages/mcp-server/**/*.ts": [
-      "npx tsc --noEmit -p packages/mcp-server/tsconfig.json"
+      "bash -c 'npx tsc --noEmit -p packages/mcp-server/tsconfig.json'"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Fix pre-commit hook failure when staging backend or mcp-server `.ts` files
- lint-staged appends matched file paths as arguments, but `tsc -p tsconfig.json` cannot accept file arguments alongside `-p` (causes TS5042)
- Wrap the tsc commands in `bash -c` so the appended file list is ignored

## Context
Reported by @Ein in PR #11 — the pre-commit hook from PR #7 fails on backend changes.

## Test plan
- [ ] Stage a `.ts` file in `packages/backend/` and run `npx lint-staged` — should pass without TS5042
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)