### PR TITLE
docs: document TEAM_MEMORY_DB for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Backend
 PORT=3456                                    # Backend server port
+TEAM_MEMORY_DB=./team-memory.db              # Optional SQLite path; use an absolute path for shared or long-running deployments
 
 # Dashboard
 VITE_API_BASE=http://localhost:3456/api       # Backend API URL for dashboard

--- a/README.md
+++ b/README.md
@@ -98,18 +98,33 @@ There is no repo-root workspace script yet. Install and run each package from it
 
 The backend defaults to port `3456`, but the current dashboard client points at `http://localhost:3457/api`.
 
+The backend SQLite file also defaults to `<current working directory>/team-memory.db`. That is fine for quick local demos, but for any shared or long-running instance you should set `TEAM_MEMORY_DB` explicitly so the database location does not drift with the shell's CWD.
+
 If you want the dashboard to work without editing source, run the backend on `3457`:
 
 ```bash
 cd packages/backend
 npm install
-PORT=3457 npm run dev
+PORT=3457 TEAM_MEMORY_DB=/absolute/path/to/team-memory.db npm run dev
 ```
 
 Health check:
 
 ```bash
 curl http://localhost:3457/health
+```
+
+If you are running a shared backend for multiple agents, use an absolute path, for example:
+
+```bash
+TEAM_MEMORY_DB=/Users/you/.slock/shared/team-memory/team-memory.db
+```
+
+The backend key-management CLI uses the same env var, so point it at the same DB before creating or revoking keys:
+
+```bash
+TEAM_MEMORY_DB=/absolute/path/to/team-memory.db \
+npm run keys --workspace=packages/backend -- create <owner>
 ```
 
 ### 2. Start the MCP server


### PR DESCRIPTION
## Summary
- add `TEAM_MEMORY_DB` to `.env.example` as a supported backend env var
- document that the backend DB path otherwise falls back to the current working directory
- document that the key-management CLI must use the same `TEAM_MEMORY_DB` when operating on a shared instance

Fixes #13