### PR TITLE
Phase 3 M1: add embedding infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Backend
 PORT=3456                                    # Backend server port (change this if 3456 is occupied, e.g. 3460)
 TEAM_MEMORY_DB=./team-memory.db              # Optional SQLite path; use an absolute path for shared or long-running deployments
+EMBEDDING_API_KEY=                           # Optional; when unset, embedding generation degrades gracefully
+EMBEDDING_API_BASE=https://api.openai.com/v1 # Set to https://openrouter.ai/api/v1 when using OpenRouter
+EMBEDDING_MODEL=text-embedding-3-small       # For OpenRouter, e.g. openai/text-embedding-3-small
 
 # Dashboard
 VITE_API_BASE=http://localhost:3456/api       # Backend API URL for dashboard; keep this aligned with PORT

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "keys": "tsx src/cli.ts",
+    "embeddings:backfill": "tsx src/backfill-embeddings.ts",
     "test": "node --import tsx --test tests/**/*.test.ts"
   },
   "dependencies": {

--- a/packages/backend/src/backfill-embeddings.ts
+++ b/packages/backend/src/backfill-embeddings.ts
@@ -1,0 +1,31 @@
+import { closeDb, getDb } from "./db.js";
+import { backfillMissingEmbeddings } from "./embedding.js";
+
+function parseBatchSize(raw: string | undefined): number {
+  if (!raw) return 100;
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value <= 0) {
+    console.error("Batch size must be a positive integer.");
+    process.exit(1);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const batchSize = parseBatchSize(process.argv[2]);
+  const db = getDb();
+  const result = await backfillMissingEmbeddings(db, { batchSize });
+
+  console.log(`Embedding backfill complete.`);
+  console.log(`scanned=${result.scanned}`);
+  console.log(`updated=${result.updated}`);
+}
+
+void main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    closeDb();
+  });

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -83,6 +83,7 @@ export function getDb(): Database.Database {
 
   ensureColumn(_db, "knowledge", "duplicate_of", "TEXT");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_knowledge_duplicate_of ON knowledge(duplicate_of)");
+  ensureColumn(_db, "knowledge", "embedding", "BLOB");
   cleanupFalsePositiveDuplicateOf(_db);
 
   return _db;

--- a/packages/backend/src/embedding.ts
+++ b/packages/backend/src/embedding.ts
@@ -1,0 +1,116 @@
+import type Database from "better-sqlite3";
+
+const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+const DEFAULT_EMBEDDING_API_BASE = "https://api.openai.com/v1";
+
+interface EmbeddingApiResponse {
+  data?: Array<{
+    index: number;
+    embedding: number[];
+  }>;
+}
+
+function getEmbeddingApiKey(): string | null {
+  const value = process.env.EMBEDDING_API_KEY?.trim() ?? process.env.OPENAI_API_KEY?.trim();
+  return value ? value : null;
+}
+
+function getEmbeddingApiBase(): string {
+  const value = process.env.EMBEDDING_API_BASE?.trim() || DEFAULT_EMBEDDING_API_BASE;
+  return value.replace(/\/+$/, "");
+}
+
+function getEmbeddingModel(): string {
+  const value = process.env.EMBEDDING_MODEL?.trim() || DEFAULT_EMBEDDING_MODEL;
+  return value;
+}
+
+export function buildKnowledgeEmbeddingText(claim: string, detail?: string | null): string {
+  return detail ? `${claim}\n\n${detail}` : claim;
+}
+
+export function encodeEmbedding(vector: number[] | Float32Array | null): Buffer | null {
+  if (!vector) return null;
+  const floatArray = vector instanceof Float32Array ? vector : Float32Array.from(vector);
+  return Buffer.from(floatArray.buffer.slice(floatArray.byteOffset, floatArray.byteOffset + floatArray.byteLength));
+}
+
+export async function embedTexts(texts: string[]): Promise<Array<Float32Array | null>> {
+  if (texts.length === 0) return [];
+
+  const apiKey = getEmbeddingApiKey();
+  if (!apiKey) {
+    return texts.map(() => null);
+  }
+
+  try {
+    const response = await fetch(`${getEmbeddingApiBase()}/embeddings`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: getEmbeddingModel(),
+        input: texts,
+        encoding_format: "float",
+      }),
+    });
+
+    if (!response.ok) {
+      return texts.map(() => null);
+    }
+
+    const payload = (await response.json()) as EmbeddingApiResponse;
+    const rows = payload.data ?? [];
+    const byIndex = new Map(rows.map((row) => [row.index, Float32Array.from(row.embedding)]));
+    return texts.map((_, index) => byIndex.get(index) ?? null);
+  } catch {
+    return texts.map(() => null);
+  }
+}
+
+export async function embedKnowledgeItem(claim: string, detail?: string | null): Promise<Buffer | null> {
+  const [vector] = await embedTexts([buildKnowledgeEmbeddingText(claim, detail)]);
+  return encodeEmbedding(vector);
+}
+
+export async function backfillMissingEmbeddings(
+  db: { prepare: Database.Database["prepare"]; transaction: Database.Database["transaction"] },
+  options: { batchSize?: number } = {},
+): Promise<{ updated: number; scanned: number }> {
+  const batchSize = Math.max(1, options.batchSize ?? 100);
+  const selectMissing = db.prepare(
+    "SELECT id, claim, detail FROM knowledge WHERE embedding IS NULL ORDER BY created_at ASC LIMIT ?",
+  );
+  const updateEmbedding = db.prepare("UPDATE knowledge SET embedding = ?, updated_at = ? WHERE id = ?");
+
+  let scanned = 0;
+  let updated = 0;
+
+  while (true) {
+    const rows = selectMissing.all(batchSize) as Array<{ id: string; claim: string; detail: string | null }>;
+    if (rows.length === 0) {
+      break;
+    }
+
+    scanned += rows.length;
+    const vectors = await embedTexts(rows.map((row) => buildKnowledgeEmbeddingText(row.claim, row.detail)));
+    const now = new Date().toISOString();
+
+    db.transaction(() => {
+      rows.forEach((row, index) => {
+        const encoded = encodeEmbedding(vectors[index] ?? null);
+        if (!encoded) return;
+        updateEmbedding.run(encoded, now, row.id);
+        updated += 1;
+      });
+    })();
+
+    if (rows.length < batchSize) {
+      break;
+    }
+  }
+
+  return { updated, scanned };
+}

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import { requireApiAuth, requireOwnerAccess } from "./auth.js";
 import { getDb } from "./db.js";
 import { findPersistedDuplicateOf } from "./duplicates.js";
+import { embedKnowledgeItem } from "./embedding.js";
 import { detectPossibleDuplicates, qualityFlagsFromRow } from "./quality.js";
 
 const api = new Hono();
@@ -58,6 +59,7 @@ api.post("/knowledge", async (c) => {
   const db = getDb();
   const id = uuidv4();
   const now = new Date().toISOString();
+  const embedding = await embedKnowledgeItem(body.claim, body.detail ?? null);
   const duplicates = detectPossibleDuplicates(db, { claim: body.claim, project: body.project });
   const duplicateOf = findPersistedDuplicateOf(body.claim, body.project, duplicates);
 
@@ -74,11 +76,11 @@ api.post("/knowledge", async (c) => {
     }
   }
 
-  const insert = db.prepare(`INSERT INTO knowledge (id, claim, detail, source, project, module, tags, confidence, staleness_hint, owner, related_to, supersedes, superseded_by, duplicate_of, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)`);
+  const insert = db.prepare(`INSERT INTO knowledge (id, claim, detail, source, project, module, tags, confidence, staleness_hint, owner, related_to, supersedes, superseded_by, duplicate_of, embedding, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`);
   const updateSuperseded = db.prepare("UPDATE knowledge SET superseded_by = ? WHERE id = ?");
 
   db.transaction(() => {
-    insert.run(id, body.claim, body.detail ?? null, JSON.stringify(body.source), body.project, body.module ?? null, JSON.stringify(body.tags), body.confidence, body.staleness_hint, auth.owner, JSON.stringify(body.related_to ?? []), body.supersedes ?? null, duplicateOf, now, now);
+    insert.run(id, body.claim, body.detail ?? null, JSON.stringify(body.source), body.project, body.module ?? null, JSON.stringify(body.tags), body.confidence, body.staleness_hint, auth.owner, JSON.stringify(body.related_to ?? []), body.supersedes ?? null, duplicateOf, embedding, now, now);
     if (body.supersedes) updateSuperseded.run(id, body.supersedes);
   })();
 

--- a/packages/backend/tests/embedding-infra.test.ts
+++ b/packages/backend/tests/embedding-infra.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-embedding-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+process.env.EMBEDDING_API_KEY = "test-embedding-key";
+process.env.EMBEDDING_API_BASE = "https://openrouter.ai/api/v1/";
+process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+let originalFetch: typeof globalThis.fetch;
+let backfillMissingEmbeddings: (db: Database.Database, options?: { batchSize?: number }) => Promise<{ updated: number; scanned: number }>;
+
+function knowledgeText(claim: string, detail?: string) {
+  return detail ? `${claim}\n\n${detail}` : claim;
+}
+
+before(async () => {
+  originalFetch = globalThis.fetch;
+
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+  const embeddingModule = await import("../src/embedding.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+  backfillMissingEmbeddings = embeddingModule.backfillMissingEmbeddings;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  const db = getDb();
+  db.exec("DELETE FROM knowledge; DELETE FROM api_keys;");
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.TEAM_MEMORY_DB;
+  delete process.env.EMBEDDING_API_KEY;
+  delete process.env.EMBEDDING_API_BASE;
+  delete process.env.EMBEDDING_MODEL;
+});
+
+function createApiKey(owner = "Tester"): string {
+  const db = getDb();
+  const key = `${owner.toLowerCase()}-embedding-key`;
+  db.prepare(
+    "INSERT OR REPLACE INTO api_keys (key, owner, created_at, revoked_at) VALUES (?, ?, ?, NULL)",
+  ).run(key, owner, new Date().toISOString());
+  return key;
+}
+
+async function publishKnowledge(apiKey: string, body: Record<string, unknown>) {
+  return app.request("http://localhost/api/knowledge", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    claim: string;
+    detail?: string | null;
+    embedding?: Buffer | null;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim,
+    input.detail ?? null,
+    JSON.stringify(["tests/embedding-infra.test.ts"]),
+    "team-memory",
+    "search",
+    JSON.stringify(["semantic"]),
+    "high",
+    "Recheck if vector search changes",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    null,
+    null,
+    input.embedding ?? null,
+    now,
+    now,
+  );
+}
+
+test("publish stores an embedding blob when embedding generation succeeds", async () => {
+  const claim = "Control plane is the sole PostgreSQL writer.";
+  const detail = "Inference should emit usage events, not write billing rows directly.";
+
+  globalThis.fetch = (async (url, init) => {
+    assert.equal(String(url), "https://openrouter.ai/api/v1/embeddings");
+    const payload = JSON.parse(String(init?.body));
+    assert.equal(payload.model, "openai/text-embedding-3-small");
+    assert.deepEqual(payload.input, [knowledgeText(claim, detail)]);
+    assert.equal(payload.encoding_format, "float");
+
+    return new Response(
+      JSON.stringify({
+        data: [{ index: 0, embedding: [0.25, 0.5, 0.75] }],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof globalThis.fetch;
+
+  const apiKey = createApiKey();
+  const response = await publishKnowledge(apiKey, {
+    claim,
+    detail,
+    source: ["tests/embedding-infra.test.ts"],
+    project: "team-memory",
+    tags: ["architecture"],
+    confidence: "high",
+    staleness_hint: "Recheck if write path changes",
+  });
+
+  assert.equal(response.status, 201);
+  const created = (await response.json()) as { id: string };
+
+  const row = getDb()
+    .prepare("SELECT embedding FROM knowledge WHERE id = ?")
+    .get(created.id) as { embedding: Buffer | null };
+
+  assert.ok(row.embedding);
+  assert.equal(row.embedding.byteLength, Float32Array.BYTES_PER_ELEMENT * 3);
+});
+
+test("publish still succeeds when embedding generation fails", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("embedding api unavailable");
+  }) as typeof globalThis.fetch;
+
+  const apiKey = createApiKey();
+  const response = await publishKnowledge(apiKey, {
+    claim: "Semantic search should degrade gracefully when embeddings are unavailable.",
+    detail: "Publish should not fail if the embedding API is down.",
+    source: ["tests/embedding-infra.test.ts"],
+    project: "team-memory",
+    tags: ["reliability"],
+    confidence: "medium",
+    staleness_hint: "Recheck if publish pipeline changes",
+  });
+
+  assert.equal(response.status, 201);
+  const created = (await response.json()) as { id: string };
+
+  const row = getDb()
+    .prepare("SELECT embedding FROM knowledge WHERE id = ?")
+    .get(created.id) as { embedding: Buffer | null };
+
+  assert.equal(row.embedding, null);
+});
+
+test("backfill script embeds only rows that are still missing embeddings", async () => {
+  const db = getDb();
+  const existingEmbedding = Buffer.from(Float32Array.from([9, 9, 9]).buffer);
+  const missingClaim = "Semantic backfill should cover older knowledge rows.";
+  const missingDetail = "This row existed before embeddings were introduced.";
+
+  insertKnowledgeRow(db, {
+    id: "missing-embedding",
+    claim: missingClaim,
+    detail: missingDetail,
+    embedding: null,
+  });
+  insertKnowledgeRow(db, {
+    id: "existing-embedding",
+    claim: "This row already has an embedding.",
+    embedding: existingEmbedding,
+  });
+
+  globalThis.fetch = (async (_url, init) => {
+    const payload = JSON.parse(String(init?.body));
+    assert.deepEqual(payload.input, [knowledgeText(missingClaim, missingDetail)]);
+    assert.equal(payload.model, "openai/text-embedding-3-small");
+
+    return new Response(
+      JSON.stringify({
+        data: [{ index: 0, embedding: [0.1, 0.2, 0.3, 0.4] }],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof globalThis.fetch;
+
+  const result = await backfillMissingEmbeddings(db, { batchSize: 10 });
+
+  assert.equal(result.scanned, 1);
+  assert.equal(result.updated, 1);
+
+  const rows = db
+    .prepare("SELECT id, embedding FROM knowledge ORDER BY id ASC")
+    .all() as Array<{ id: string; embedding: Buffer | null }>;
+
+  assert.equal(rows[0]?.id, "existing-embedding");
+  assert.deepEqual(rows[0]?.embedding, existingEmbedding);
+  assert.equal(rows[1]?.id, "missing-embedding");
+  assert.ok(rows[1]?.embedding);
+  assert.notDeepEqual(rows[1]?.embedding, existingEmbedding);
+});


### PR DESCRIPTION
## Summary
- add provider-agnostic embedding client for backend publish flow
- persist embedding blobs on knowledge creation and add a backfill script for legacy rows
- document embedding provider env vars in `.env.example` and add backend tests for success/failure/backfill paths

## Details
- new env vars:
  - `EMBEDDING_API_KEY`
  - `EMBEDDING_API_BASE`
  - `EMBEDDING_MODEL`
- still degrades gracefully when no embedding key is configured or when the provider call fails
- adds `npm run embeddings:backfill --workspace=packages/backend` for one-off backfill jobs

## Validation
- `npm run test --workspace=packages/backend`
- `npm run build --workspace=packages/backend`
- real OpenRouter smoke test passed in an isolated worktree + temp DB:
  - publish persisted embedding
  - backfill updated one legacy row with missing embedding
  - both rows stored non-empty `embedding` BLOBs (6144 bytes)
