### PR TITLE
Phase 3 M2: add semantic search backend

### DIFF
--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -3,8 +3,9 @@ import { v4 as uuidv4 } from "uuid";
 import { requireApiAuth, requireOwnerAccess } from "./auth.js";
 import { getDb } from "./db.js";
 import { findPersistedDuplicateOf } from "./duplicates.js";
-import { embedKnowledgeItem } from "./embedding.js";
+import { embedKnowledgeItem, embedTexts } from "./embedding.js";
 import { detectPossibleDuplicates, qualityFlagsFromRow } from "./quality.js";
+import { cosineSimilarity, decodeEmbedding } from "./vector.js";
 
 const api = new Hono();
 
@@ -14,6 +15,10 @@ interface KnowledgeRow {
   staleness_hint: string; owner: string; related_to: string;
   supersedes: string | null; superseded_by: string | null; duplicate_of: string | null;
   created_at: string; updated_at: string;
+}
+
+interface SemanticKnowledgeRow extends KnowledgeRow {
+  embedding: Buffer | null;
 }
 
 function rowToJson(row: KnowledgeRow) {
@@ -122,7 +127,51 @@ api.get("/knowledge/search", (c) => {
   return c.json({ items: filtered.map((row) => ({ ...summaryFromRow(row), rank: row.rank })), total: tags ? filtered.length : rows.length });
 });
 
-// 3. GET /api/knowledge
+// 3. GET /api/knowledge/semantic-search
+api.get("/knowledge/semantic-search", async (c) => {
+  const q = c.req.query("q");
+  if (!q) return c.json({ error: "Query parameter 'q' is required" }, 400);
+
+  const project = c.req.query("project");
+  const limit = Math.min(parseInt(c.req.query("limit") ?? "10", 10) || 10, 100);
+  const db = getDb();
+
+  const [queryEmbedding] = await embedTexts([q]);
+  if (!queryEmbedding) {
+    return c.json({ items: [], total: 0 });
+  }
+
+  const params: (string | number)[] = [];
+  const conditions = ["embedding IS NOT NULL", "superseded_by IS NULL"];
+  if (project) {
+    conditions.push("project = ?");
+    params.push(project);
+  }
+
+  const rows = db.prepare(
+    `SELECT * FROM knowledge WHERE ${conditions.join(" AND ")} ORDER BY created_at DESC`,
+  ).all(...params) as SemanticKnowledgeRow[];
+
+  const ranked = rows
+    .map((row) => {
+      const storedEmbedding = decodeEmbedding(row.embedding);
+      if (!storedEmbedding) return null;
+
+      return {
+        ...summaryFromRow(row),
+        similarity: cosineSimilarity(queryEmbedding, storedEmbedding),
+      };
+    })
+    .filter((row): row is ReturnType<typeof summaryFromRow> & { similarity: number } => row !== null)
+    .sort((left, right) => right.similarity - left.similarity);
+
+  return c.json({
+    items: ranked.slice(0, limit),
+    total: ranked.length,
+  });
+});
+
+// 4. GET /api/knowledge
 api.get("/knowledge", (c) => {
   const project = c.req.query("project");
   const tags = c.req.query("tags");
@@ -149,7 +198,7 @@ api.get("/knowledge", (c) => {
   return c.json({ items, total: tags ? items.length : countRow.cnt, limit, offset });
 });
 
-// 4. GET /api/knowledge/:id
+// 5. GET /api/knowledge/:id
 api.get("/knowledge/:id", (c) => {
   const db = getDb();
   const row = db.prepare("SELECT * FROM knowledge WHERE id = ?").get(c.req.param("id")) as KnowledgeRow | undefined;
@@ -157,7 +206,7 @@ api.get("/knowledge/:id", (c) => {
   return c.json(rowToJson(row));
 });
 
-// 5. PATCH /api/knowledge/:id
+// 6. PATCH /api/knowledge/:id
 api.patch("/knowledge/:id", async (c) => {
   const id = c.req.param("id");
   const body = await c.req.json();

--- a/packages/backend/src/vector.ts
+++ b/packages/backend/src/vector.ts
@@ -1,0 +1,30 @@
+export function decodeEmbedding(buffer: Buffer | Uint8Array | null): Float32Array | null {
+  if (!buffer) return null;
+  const view = buffer instanceof Buffer ? buffer : Buffer.from(buffer);
+  if (view.byteLength === 0 || view.byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) {
+    return null;
+  }
+
+  return new Float32Array(
+    view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength),
+  );
+}
+
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  if (a.length === 0 || a.length !== b.length) return 0;
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let index = 0; index < a.length; index += 1) {
+    const left = a[index]!;
+    const right = b[index]!;
+    dot += left * right;
+    normA += left * left;
+    normB += right * right;
+  }
+
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/packages/backend/tests/semantic-search.test.ts
+++ b/packages/backend/tests/semantic-search.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-semantic-search-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+process.env.EMBEDDING_API_KEY = "test-semantic-key";
+process.env.EMBEDDING_API_BASE = "https://openrouter.ai/api/v1";
+process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
+
+interface SemanticSummary {
+  id: string;
+  claim: string;
+  project: string;
+  similarity: number;
+}
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+let originalFetch: typeof globalThis.fetch;
+
+function encodeEmbedding(vector: number[]): Buffer {
+  return Buffer.from(Float32Array.from(vector).buffer);
+}
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    claim: string;
+    embedding?: Buffer | null;
+    project?: string;
+    supersededBy?: string | null;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim,
+    null,
+    JSON.stringify(["tests/semantic-search.test.ts"]),
+    input.project ?? "team-memory",
+    "search",
+    JSON.stringify(["semantic-search"]),
+    "high",
+    "Recheck if semantic ranking changes",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    input.supersededBy ?? null,
+    null,
+    input.embedding ?? null,
+    now,
+    now,
+  );
+}
+
+before(async () => {
+  originalFetch = globalThis.fetch;
+
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  const db = getDb();
+  db.exec("DELETE FROM knowledge; DELETE FROM api_keys;");
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.TEAM_MEMORY_DB;
+  delete process.env.EMBEDDING_API_KEY;
+  delete process.env.EMBEDDING_API_BASE;
+  delete process.env.EMBEDDING_MODEL;
+});
+
+test("semantic search ranks by cosine similarity and filters superseded/project rows", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "similar-row",
+    claim: "Control plane owns write-side billing persistence.",
+    embedding: encodeEmbedding([1, 0]),
+  });
+  insertKnowledgeRow(db, {
+    id: "second-row",
+    claim: "Inference emits usage events before control persists them.",
+    embedding: encodeEmbedding([0.6, 0.8]),
+  });
+  insertKnowledgeRow(db, {
+    id: "superseded-row",
+    claim: "This row should be filtered even if its embedding is perfect.",
+    embedding: encodeEmbedding([1, 0]),
+    supersededBy: "newer-row",
+  });
+  insertKnowledgeRow(db, {
+    id: "other-project-row",
+    claim: "This row belongs to another project and should be filtered.",
+    embedding: encodeEmbedding([1, 0]),
+    project: "other-project",
+  });
+
+  globalThis.fetch = (async (_url, init) => {
+    const payload = JSON.parse(String(init?.body));
+    assert.equal(payload.model, "openai/text-embedding-3-small");
+    assert.deepEqual(payload.input, ["database writer ownership"]);
+
+    return new Response(
+      JSON.stringify({
+        data: [{ index: 0, embedding: [1, 0] }],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof globalThis.fetch;
+
+  const response = await app.request("http://localhost/api/knowledge/semantic-search?q=database%20writer%20ownership&project=team-memory&limit=5");
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { items: SemanticSummary[]; total: number };
+
+  assert.equal(body.total, 2);
+  assert.deepEqual(
+    body.items.map((item) => item.id),
+    ["similar-row", "second-row"],
+  );
+  assert.ok(body.items[0]!.similarity > body.items[1]!.similarity);
+});
+
+test("semantic search returns empty results when query embedding cannot be generated", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "existing-row",
+    claim: "A row with an embedding should not cause semantic search to fail.",
+    embedding: encodeEmbedding([1, 0, 0]),
+  });
+
+  delete process.env.EMBEDDING_API_KEY;
+
+  const response = await app.request("http://localhost/api/knowledge/semantic-search?q=missing%20provider");
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { items: SemanticSummary[]; total: number };
+  assert.deepEqual(body, { items: [], total: 0 });
+
+  process.env.EMBEDDING_API_KEY = "test-semantic-key";
+});


### PR DESCRIPTION
## Summary
- add `/api/knowledge/semantic-search` for embedding-based retrieval
- add vector decoding + cosine similarity helpers
- cover semantic ranking, superseded/project filtering, and graceful empty fallback with backend tests

## API contract
`GET /api/knowledge/semantic-search?q=<query>&project=<optional>&limit=<optional>`

Response:
```json
{
  "items": [
    {
      "id": "...",
      "claim": "...",
      "project": "...",
      "module": "...",
      "tags": ["..."],
      "confidence": "high",
      "staleness_hint": "...",
      "owner": "...",
      "duplicate_of": null,
      "created_at": "...",
      "is_stale": false,
      "stale_after_days": 30,
      "stale_at": "...",
      "effective_confidence": "high",
      "similarity": 0.92
    }
  ],
  "total": 2
}
```

Notes:
- excludes superseded rows by default
- supports optional `project` filter
- excludes rows with missing embeddings
- if query embedding cannot be generated, returns `{ items: [], total: 0 }`

## Validation
- `PATH=/Users/zooey/.nvm/versions/node/v22.22.0/bin:$PATH npm run test --workspace=packages/backend`
- `PATH=/Users/zooey/.nvm/versions/node/v22.22.0/bin:$PATH npm run build --workspace=packages/backend`
