### PR TITLE
Phase 3 M3: add hybrid search backend

### DIFF
--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -21,6 +21,25 @@ interface SemanticKnowledgeRow extends KnowledgeRow {
   embedding: Buffer | null;
 }
 
+type SearchMode = "fts" | "semantic" | "hybrid";
+
+// Prefer semantic signal, but give a small bonus when a row matches both worlds.
+const HYBRID_FTS_WEIGHT = 0.35;
+const HYBRID_SEMANTIC_WEIGHT = 0.65;
+const HYBRID_MATCH_BONUS = 0.15;
+const SEMANTIC_ONLY_WEIGHT = 0.75;
+const FTS_ONLY_WEIGHT = 0.55;
+
+interface FtsSearchRow extends KnowledgeRow {
+  rank: number;
+}
+
+interface SearchResultItem extends ReturnType<typeof summaryFromRow> {
+  rank?: number;
+  similarity?: number;
+  search_mode: SearchMode;
+}
+
 function rowToJson(row: KnowledgeRow) {
   return {
     id: row.id, claim: row.claim, detail: row.detail,
@@ -42,6 +61,102 @@ function summaryFromRow(row: KnowledgeRow) {
     duplicate_of: row.duplicate_of, created_at: row.created_at,
     ...qualityFlagsFromRow(row),
   };
+}
+
+function parseTagList(tags: string | null | undefined): string[] | undefined {
+  if (!tags) return undefined;
+  const list = tags.split(",").map((tag) => tag.trim().toLowerCase()).filter(Boolean);
+  return list.length > 0 ? list : undefined;
+}
+
+function matchesRequestedTags(row: KnowledgeRow, tags: string[] | undefined): boolean {
+  if (!tags || tags.length === 0) return true;
+  const rowTags: string[] = JSON.parse(row.tags).map((tag: string) => tag.toLowerCase());
+  return tags.some((tag) => rowTags.includes(tag));
+}
+
+function normalizedFtsScores(rows: FtsSearchRow[]): Map<string, number> {
+  if (rows.length === 0) return new Map();
+  if (rows.length === 1) return new Map([[rows[0]!.id, 1]]);
+
+  const ranks = rows.map((row) => row.rank);
+  const best = Math.min(...ranks);
+  const worst = Math.max(...ranks);
+  if (best === worst) {
+    return new Map(rows.map((row) => [row.id, 1]));
+  }
+
+  return new Map(
+    rows.map((row) => [row.id, (worst - row.rank) / (worst - best)]),
+  );
+}
+
+function compareSearchResults(left: SearchResultItem & { hybrid_score: number }, right: SearchResultItem & { hybrid_score: number }): number {
+  if (right.hybrid_score !== left.hybrid_score) {
+    return right.hybrid_score - left.hybrid_score;
+  }
+  const modePriority: Record<SearchMode, number> = {
+    hybrid: 3,
+    semantic: 2,
+    fts: 1,
+  };
+  if (modePriority[right.search_mode] !== modePriority[left.search_mode]) {
+    return modePriority[right.search_mode] - modePriority[left.search_mode];
+  }
+  return Date.parse(right.created_at) - Date.parse(left.created_at);
+}
+
+async function runSemanticCandidates(
+  db: ReturnType<typeof getDb>,
+  input: {
+    query: string;
+    project?: string;
+    module?: string;
+    includeSuperseded: boolean;
+    tags?: string[];
+    candidateLimit: number;
+  },
+): Promise<Array<ReturnType<typeof summaryFromRow> & { similarity: number }>> {
+  const [queryEmbedding] = await embedTexts([input.query]);
+  if (!queryEmbedding) {
+    return [];
+  }
+
+  const params: (string | number)[] = [];
+  const conditions = ["embedding IS NOT NULL"];
+  if (!input.includeSuperseded) {
+    conditions.push("superseded_by IS NULL");
+  }
+  if (input.project) {
+    conditions.push("project = ?");
+    params.push(input.project);
+  }
+  if (input.module) {
+    conditions.push("module = ?");
+    params.push(input.module);
+  }
+
+  const rows = db.prepare(
+    `SELECT * FROM knowledge WHERE ${conditions.join(" AND ")} ORDER BY created_at DESC`,
+  ).all(...params) as SemanticKnowledgeRow[];
+
+  return rows
+    .filter((row) => matchesRequestedTags(row, input.tags))
+    .map((row) => {
+      const storedEmbedding = decodeEmbedding(row.embedding);
+      if (!storedEmbedding) return null;
+
+      const similarity = cosineSimilarity(queryEmbedding, storedEmbedding);
+      if (similarity <= 0) return null;
+
+      return {
+        ...summaryFromRow(row),
+        similarity,
+      };
+    })
+    .filter((row): row is ReturnType<typeof summaryFromRow> & { similarity: number } => row !== null)
+    .sort((left, right) => right.similarity - left.similarity)
+    .slice(0, input.candidateLimit);
 }
 
 const VALID_CONFIDENCE = new Set(["high", "medium", "low"]);
@@ -102,7 +217,7 @@ api.post("/knowledge", async (c) => {
 });
 
 // 2. GET /api/knowledge/search
-api.get("/knowledge/search", (c) => {
+api.get("/knowledge/search", async (c) => {
   const q = c.req.query("q");
   if (!q) return c.json({ error: "Query parameter 'q' is required" }, 400);
   const project = c.req.query("project");
@@ -111,6 +226,8 @@ api.get("/knowledge/search", (c) => {
   const includeSuperseded = c.req.query("include_superseded") === "true";
   const limit = Math.min(parseInt(c.req.query("limit") ?? "20", 10) || 20, 100);
   const db = getDb();
+  const requestedTags = parseTagList(tags);
+  const candidateLimit = Math.max(limit * 3, limit);
   const conditions: string[] = [];
   const params: (string | number)[] = [];
   if (!includeSuperseded) conditions.push("k.superseded_by IS NULL");
@@ -118,13 +235,65 @@ api.get("/knowledge/search", (c) => {
   if (module_) { conditions.push("k.module = ?"); params.push(module_); }
   const whereClause = conditions.length > 0 ? `AND ${conditions.join(" AND ")}` : "";
   const sql = `SELECT k.*, rank FROM knowledge_fts fts JOIN knowledge k ON k.rowid = fts.rowid WHERE knowledge_fts MATCH ? ${whereClause} ORDER BY rank LIMIT ?`;
-  const rows = db.prepare(sql).all(q, ...params, limit) as (KnowledgeRow & { rank: number })[];
-  let filtered = rows;
-  if (tags) {
-    const tagList = tags.split(",").map((t) => t.trim().toLowerCase());
-    filtered = rows.filter((row) => { const rowTags: string[] = JSON.parse(row.tags).map((t: string) => t.toLowerCase()); return tagList.some((t) => rowTags.includes(t)); });
+  const ftsRows = db.prepare(sql).all(q, ...params, candidateLimit) as FtsSearchRow[];
+  const filteredFtsRows = ftsRows.filter((row) => matchesRequestedTags(row, requestedTags));
+  const ftsScores = normalizedFtsScores(filteredFtsRows);
+
+  const semanticRows = await runSemanticCandidates(db, {
+    query: q,
+    project: project ?? undefined,
+    module: module_ ?? undefined,
+    includeSuperseded,
+    tags: requestedTags,
+    candidateLimit,
+  });
+
+  const merged = new Map<string, SearchResultItem & { hybrid_score: number; fts_score: number; semantic_score: number }>();
+
+  for (const row of filteredFtsRows) {
+    const ftsScore = ftsScores.get(row.id) ?? 0;
+    merged.set(row.id, {
+      ...summaryFromRow(row),
+      rank: row.rank,
+      search_mode: "fts",
+      hybrid_score: ftsScore * FTS_ONLY_WEIGHT,
+      fts_score: ftsScore,
+      semantic_score: 0,
+    });
   }
-  return c.json({ items: filtered.map((row) => ({ ...summaryFromRow(row), rank: row.rank })), total: tags ? filtered.length : rows.length });
+
+  for (const row of semanticRows) {
+    const existing = merged.get(row.id);
+    if (existing) {
+      const semanticScore = row.similarity;
+      merged.set(row.id, {
+        ...existing,
+        similarity: row.similarity,
+        search_mode: "hybrid",
+        semantic_score: semanticScore,
+        hybrid_score:
+          existing.fts_score * HYBRID_FTS_WEIGHT
+          + semanticScore * HYBRID_SEMANTIC_WEIGHT
+          + HYBRID_MATCH_BONUS,
+      });
+      continue;
+    }
+
+    merged.set(row.id, {
+      ...row,
+      search_mode: "semantic",
+      hybrid_score: row.similarity * SEMANTIC_ONLY_WEIGHT,
+      fts_score: 0,
+      semantic_score: row.similarity,
+    });
+  }
+
+  const items = Array.from(merged.values())
+    .sort(compareSearchResults)
+    .slice(0, limit)
+    .map(({ hybrid_score: _hybridScore, fts_score: _ftsScore, semantic_score: _semanticScore, ...item }) => item);
+
+  return c.json({ items, total: merged.size });
 });
 
 // 3. GET /api/knowledge/semantic-search

--- a/packages/backend/tests/hybrid-search.test.ts
+++ b/packages/backend/tests/hybrid-search.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-hybrid-search-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+process.env.EMBEDDING_API_KEY = "test-hybrid-key";
+process.env.EMBEDDING_API_BASE = "https://openrouter.ai/api/v1";
+process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
+
+interface HybridSummary {
+  id: string;
+  claim: string;
+  search_mode: "fts" | "semantic" | "hybrid";
+  similarity?: number;
+}
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+let originalFetch: typeof globalThis.fetch;
+
+function encodeEmbedding(vector: number[]): Buffer {
+  return Buffer.from(Float32Array.from(vector).buffer);
+}
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    claim: string;
+    embedding?: Buffer | null;
+    project?: string;
+    supersededBy?: string | null;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim,
+    null,
+    JSON.stringify(["tests/hybrid-search.test.ts"]),
+    input.project ?? "team-memory",
+    "search",
+    JSON.stringify(["hybrid-search"]),
+    "high",
+    "Recheck if ranking strategy changes",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    input.supersededBy ?? null,
+    null,
+    input.embedding ?? null,
+    now,
+    now,
+  );
+}
+
+before(async () => {
+  originalFetch = globalThis.fetch;
+
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  const db = getDb();
+  db.exec("DELETE FROM knowledge; DELETE FROM api_keys;");
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.TEAM_MEMORY_DB;
+  delete process.env.EMBEDDING_API_KEY;
+  delete process.env.EMBEDDING_API_BASE;
+  delete process.env.EMBEDDING_MODEL;
+});
+
+test("hybrid search merges fts and semantic results with search_mode annotations", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "hybrid-row",
+    claim: "refund flow recovery design",
+    embedding: encodeEmbedding([1, 0]),
+  });
+  insertKnowledgeRow(db, {
+    id: "semantic-row",
+    claim: "chargeback reversal pipeline",
+    embedding: encodeEmbedding([0.96, 0.04]),
+  });
+  insertKnowledgeRow(db, {
+    id: "fts-only-row",
+    claim: "refund flow audit logs",
+    embedding: null,
+  });
+  insertKnowledgeRow(db, {
+    id: "other-project-row",
+    claim: "refund flow but in another project",
+    embedding: encodeEmbedding([1, 0]),
+    project: "other-project",
+  });
+
+  globalThis.fetch = (async (_url, init) => {
+    const payload = JSON.parse(String(init?.body));
+    assert.deepEqual(payload.input, ["refund flow"]);
+
+    return new Response(
+      JSON.stringify({
+        data: [{ index: 0, embedding: [1, 0] }],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof globalThis.fetch;
+
+  const response = await app.request("http://localhost/api/knowledge/search?q=refund%20flow&project=team-memory&limit=10");
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { items: HybridSummary[]; total: number };
+
+  assert.equal(body.total, 3);
+  assert.equal(body.items[0]?.id, "hybrid-row");
+
+  const byId = new Map(body.items.map((item) => [item.id, item]));
+  assert.equal(byId.get("hybrid-row")?.search_mode, "hybrid");
+  assert.equal(byId.get("semantic-row")?.search_mode, "semantic");
+  assert.equal(byId.get("fts-only-row")?.search_mode, "fts");
+  assert.equal(byId.has("other-project-row"), false);
+  assert.ok((byId.get("hybrid-row")?.similarity ?? 0) > 0.9);
+  assert.ok((byId.get("semantic-row")?.similarity ?? 0) > 0.9);
+});
+
+test("hybrid search falls back to pure FTS when query embeddings are unavailable", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "fts-row",
+    claim: "refund flow audit logs",
+    embedding: null,
+  });
+  insertKnowledgeRow(db, {
+    id: "semantic-only-row",
+    claim: "chargeback reversal pipeline",
+    embedding: encodeEmbedding([1, 0]),
+  });
+
+  delete process.env.EMBEDDING_API_KEY;
+
+  const response = await app.request("http://localhost/api/knowledge/search?q=refund%20flow");
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { items: HybridSummary[]; total: number };
+
+  assert.equal(body.total, 1);
+  assert.deepEqual(body.items.map((item) => item.id), ["fts-row"]);
+  assert.equal(body.items[0]?.search_mode, "fts");
+
+  process.env.EMBEDDING_API_KEY = "test-hybrid-key";
+});


### PR DESCRIPTION
## Summary
- upgrade `GET /api/knowledge/search` to merge FTS and semantic candidates
- annotate results with `search_mode` (`fts`, `semantic`, `hybrid`) and include semantic similarity when available
- add backend tests covering hybrid merge behavior and pure-FTS fallback

## Validation
- `PATH=/Users/zooey/.nvm/versions/node/v22.22.0/bin:$PATH npm run test --workspace=packages/backend`
- `PATH=/Users/zooey/.nvm/versions/node/v22.22.0/bin:$PATH npm run build --workspace=packages/backend`

## Notes
- hybrid ranking currently prefers dual-signal matches over pure FTS-only hits
- response items now expose `search_mode`, which unblocks dashboard work in #34
