### PR TITLE
feat(dashboard): search mode indicator and similarity scores

### DIFF
--- a/packages/dashboard/src/App.css
+++ b/packages/dashboard/src/App.css
@@ -174,6 +174,41 @@
   color: var(--text-dim);
 }
 
+/* Search mode badge */
+.search-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.search-mode-badge.fts {
+  background: var(--tag-bg);
+  color: var(--tag-text);
+}
+
+.search-mode-badge.semantic {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+.search-mode-badge.hybrid {
+  background: linear-gradient(135deg, var(--tag-bg), var(--accent-bg));
+  color: var(--accent);
+}
+
+/* Similarity score */
+.similarity {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
 /* Knowledge list */
 .knowledge-list {
   flex: 1;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -22,6 +22,7 @@ function App() {
   const [projects, setProjects] = useState<string[]>([]);
   const [owners, setOwners] = useState<string[]>([]);
   const [tags, setTags] = useState<string[]>([]);
+  const [searchMode, setSearchMode] = useState<"fts" | "semantic" | "hybrid" | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [apiKeyInput, setApiKeyInput] = useState(getApiKey() ?? "");
 
@@ -48,6 +49,7 @@ function App() {
     }
     setItems(result.items);
     setTotal(result.total);
+    setSearchMode(result.search_mode ?? null);
   }, [query, filterProject, filterOwner, filterTag]);
 
   useEffect(() => {
@@ -152,6 +154,11 @@ function App() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
             />
+            {searchMode && query.trim() && (
+              <span className={`search-mode-badge ${searchMode}`}>
+                {searchMode}
+              </span>
+            )}
             {hasFilters && (
               <button className="filter-btn" onClick={clearFilters}>
                 Clear
@@ -191,6 +198,9 @@ function App() {
                     <span className={`confidence ${item.effective_confidence ?? item.confidence}`}>
                       {item.effective_confidence ?? item.confidence}
                     </span>
+                    {item.similarity != null && (
+                      <span className="similarity">{Math.round(item.similarity * 100)}% match</span>
+                    )}
                     <span>{item.project}</span>
                     {item.module && <span>/ {item.module}</span>}
                     <span>by {item.owner}</span>

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -49,7 +49,15 @@ function App() {
     }
     setItems(result.items);
     setTotal(result.total);
-    setSearchMode(result.search_mode ?? null);
+    if (query.trim() && result.items.length > 0) {
+      const modes = new Set(result.items.map((i) => i.search_mode).filter(Boolean));
+      if (modes.has("hybrid") || modes.size > 1) setSearchMode("hybrid");
+      else if (modes.has("semantic")) setSearchMode("semantic");
+      else if (modes.has("fts")) setSearchMode("fts");
+      else setSearchMode(null);
+    } else {
+      setSearchMode(null);
+    }
   }, [query, filterProject, filterOwner, filterTag]);
 
   useEffect(() => {

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -48,7 +48,6 @@ interface SearchParams {
 interface PaginatedResponse<T> {
   items: T[];
   total: number;
-  search_mode?: "fts" | "semantic" | "hybrid";
 }
 
 // --- Mock implementations ---

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -48,6 +48,7 @@ interface SearchParams {
 interface PaginatedResponse<T> {
   items: T[];
   total: number;
+  search_mode?: "fts" | "semantic" | "hybrid";
 }
 
 // --- Mock implementations ---

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -36,5 +36,6 @@ export interface KnowledgeListItem {
   stale_at?: string;
   effective_confidence?: "high" | "medium" | "low";
   similarity?: number;
+  search_mode?: "fts" | "semantic" | "hybrid";
   created_at: string;
 }

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -35,5 +35,6 @@ export interface KnowledgeListItem {
   stale_after_days?: number;
   stale_at?: string;
   effective_confidence?: "high" | "medium" | "low";
+  similarity?: number;
   created_at: string;
 }


### PR DESCRIPTION
## Summary
- Display **search mode badge** (FTS / semantic / hybrid) next to search bar when a search is active
- Show **similarity percentage** on list items returned by semantic/hybrid search
- Color-coded badges: FTS (neutral), semantic (accent purple), hybrid (gradient)

## Dependencies
- Requires PR #23 (backend hybrid search with `search_mode` field) to be merged first

## Changes
- `types.ts` — add `similarity` field to `KnowledgeListItem`
- `api.ts` — add `search_mode` to `PaginatedResponse`
- `App.tsx` — `searchMode` state, badge display in search bar, similarity display in list items
- `App.css` — `.search-mode-badge` styles (fts/semantic/hybrid variants), `.similarity` style

## Test plan
- [ ] Search with keywords → badge shows "FTS" (or "hybrid" if embeddings available)
- [ ] Semantic/hybrid results show similarity percentages
- [ ] Badge disappears when search is cleared
- [ ] No regressions when backend doesn't return search_mode (pre-M3 compat)
- [ ] Dark mode renders correctly

Part of #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)