### PR TITLE
Phase 3 M4: upgrade duplicate detection with vectors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ TEAM_MEMORY_DB=./team-memory.db              # Optional SQLite path; use an abso
 EMBEDDING_API_KEY=                           # Optional; when unset, embedding generation degrades gracefully
 EMBEDDING_API_BASE=https://api.openai.com/v1 # Set to https://openrouter.ai/api/v1 when using OpenRouter
 EMBEDDING_MODEL=text-embedding-3-small       # For OpenRouter, e.g. openai/text-embedding-3-small
+TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD=0.8  # Warn when semantic similarity reaches this threshold
+TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD=0.95 # Persist duplicate_of only above this higher threshold
 
 # Dashboard
 VITE_API_BASE=http://localhost:3456/api       # Backend API URL for dashboard; keep this aligned with PORT

--- a/packages/backend/src/duplicates.ts
+++ b/packages/backend/src/duplicates.ts
@@ -1,9 +1,10 @@
 import type Database from "better-sqlite3";
 
-interface DuplicateCandidate {
+export interface DuplicateCandidate {
   id: string;
   claim: string;
   project: string;
+  similarity?: number;
 }
 
 interface DuplicateLinkRow {
@@ -17,6 +18,11 @@ interface DuplicateLinkRow {
 
 export function normalizeClaimForDuplicateMatch(claim: string): string {
   return claim.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function semanticPersistThreshold(): number {
+  const raw = Number.parseFloat(process.env.TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD ?? "0.95");
+  return Number.isFinite(raw) && raw > 0 && raw <= 1 ? raw : 0.95;
 }
 
 function isExactDuplicateMatch(
@@ -37,10 +43,15 @@ export function findPersistedDuplicateOf(
   project: string,
   candidates: DuplicateCandidate[],
 ): string | null {
-  const match = candidates.find((candidate) =>
+  const exactMatch = candidates.find((candidate) =>
     isExactDuplicateMatch(claim, project, candidate.claim, candidate.project),
   );
-  return match?.id ?? null;
+  if (exactMatch) {
+    return exactMatch.id;
+  }
+
+  const semanticMatch = candidates.find((candidate) => (candidate.similarity ?? 0) >= semanticPersistThreshold());
+  return semanticMatch?.id ?? null;
 }
 
 export function cleanupFalsePositiveDuplicateOf(db: Database.Database): number {

--- a/packages/backend/src/quality.ts
+++ b/packages/backend/src/quality.ts
@@ -1,4 +1,6 @@
 import type Database from "better-sqlite3";
+import { normalizeClaimForDuplicateMatch } from "./duplicates.js";
+import { decodeEmbedding, cosineSimilarity } from "./vector.js";
 
 const CONFIDENCE_ORDER = ["low", "medium", "high"] as const;
 type Confidence = (typeof CONFIDENCE_ORDER)[number];
@@ -25,6 +27,7 @@ interface DuplicateRow {
   staleness_hint: string;
   owner: string;
   created_at: string;
+  embedding?: Buffer | null;
 }
 
 export interface DuplicateSummary {
@@ -37,6 +40,11 @@ export interface DuplicateSummary {
   staleness_hint: string;
   owner: string;
   created_at: string;
+  similarity?: number;
+}
+
+interface RankedDuplicateSummary extends DuplicateSummary {
+  similarity: number;
 }
 
 function normalizeConfidence(value: string): Confidence {
@@ -68,18 +76,6 @@ export function qualityFlagsFromRow(row: QualityRow): QualityFlags {
   };
 }
 
-function tokenize(text: string): string[] {
-  return Array.from(
-    new Set(
-      text
-        .toLowerCase()
-        .split(/[^a-z0-9_]+/g)
-        .map((part) => part.trim())
-        .filter((part) => part.length >= 3),
-    ),
-  ).slice(0, 8);
-}
-
 function rowToDuplicateSummary(row: DuplicateRow): DuplicateSummary {
   return {
     id: row.id,
@@ -94,50 +90,67 @@ function rowToDuplicateSummary(row: DuplicateRow): DuplicateSummary {
   };
 }
 
+function duplicateWarningThreshold(): number {
+  const raw = Number.parseFloat(process.env.TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD ?? "0.8");
+  return Number.isFinite(raw) && raw > 0 && raw <= 1 ? raw : 0.8;
+}
+
 export function detectPossibleDuplicates(
   db: Database.Database,
-  input: { claim: string; project: string; excludeId?: string | null },
+  input: { claim: string; project: string; embedding?: Buffer | null; excludeId?: string | null },
 ): DuplicateSummary[] {
   const seen = new Set<string>();
   const matches: DuplicateSummary[] = [];
   const excludeId = input.excludeId ?? null;
-
-  const exactRows = db.prepare(
-    `SELECT id, claim, project, module, tags, confidence, staleness_hint, owner, created_at
+  const projectRows = db.prepare(
+    `SELECT id, claim, project, module, tags, confidence, staleness_hint, owner, created_at, embedding
      FROM knowledge
-     WHERE lower(claim) = lower(?)
-       AND project = ?
+     WHERE project = ?
        AND superseded_by IS NULL
        AND (? IS NULL OR id != ?)
-     ORDER BY created_at DESC
-     LIMIT 3`,
-  ).all(input.claim, input.project, excludeId, excludeId) as DuplicateRow[];
+     ORDER BY created_at DESC`,
+  ).all(input.project, excludeId, excludeId) as DuplicateRow[];
+  const normalizedClaim = normalizeClaimForDuplicateMatch(input.claim);
+  const exactRows = projectRows.filter(
+    (row) => normalizeClaimForDuplicateMatch(row.claim) === normalizedClaim,
+  );
 
   for (const row of exactRows) {
     seen.add(row.id);
     matches.push(rowToDuplicateSummary(row));
+    if (matches.length >= 3) return matches;
   }
 
-  const terms = tokenize(input.claim);
-  if (terms.length === 0) return matches;
+  const currentEmbedding = decodeEmbedding(input.embedding ?? null);
+  if (!currentEmbedding) return matches;
 
-  const query = terms.join(" OR ");
-  const ftsRows = db.prepare(
-    `SELECT k.id, k.claim, k.project, k.module, k.tags, k.confidence, k.staleness_hint, k.owner, k.created_at
-     FROM knowledge_fts fts
-     JOIN knowledge k ON k.rowid = fts.rowid
-     WHERE knowledge_fts MATCH ?
-       AND k.project = ?
-       AND k.superseded_by IS NULL
-       AND (? IS NULL OR k.id != ?)
-     ORDER BY rank
-     LIMIT 5`,
-  ).all(query, input.project, excludeId, excludeId) as DuplicateRow[];
+  const warningThreshold = duplicateWarningThreshold();
+  const rankedRows = projectRows
+    .filter((row) => !seen.has(row.id) && row.embedding != null)
+    .map((row) => {
+      const storedEmbedding = decodeEmbedding(row.embedding ?? null);
+      if (!storedEmbedding) return null;
 
-  for (const row of ftsRows) {
+      const similarity = cosineSimilarity(currentEmbedding, storedEmbedding);
+      if (similarity < warningThreshold) return null;
+
+      return {
+        ...rowToDuplicateSummary(row),
+        similarity,
+      };
+    })
+    .filter((row): row is RankedDuplicateSummary => row !== null)
+    .sort((left, right) => {
+      if (right.similarity !== left.similarity) {
+        return right.similarity - left.similarity;
+      }
+      return Date.parse(right.created_at) - Date.parse(left.created_at);
+    });
+
+  for (const row of rankedRows) {
     if (seen.has(row.id)) continue;
     seen.add(row.id);
-    matches.push(rowToDuplicateSummary(row));
+    matches.push(row);
     if (matches.length >= 3) break;
   }
 

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -180,7 +180,11 @@ api.post("/knowledge", async (c) => {
   const id = uuidv4();
   const now = new Date().toISOString();
   const embedding = await embedKnowledgeItem(body.claim, body.detail ?? null);
-  const duplicates = detectPossibleDuplicates(db, { claim: body.claim, project: body.project });
+  const duplicates = detectPossibleDuplicates(db, {
+    claim: body.claim,
+    project: body.project,
+    embedding,
+  });
   const duplicateOf = findPersistedDuplicateOf(body.claim, body.project, duplicates);
 
   if (body.supersedes) {

--- a/packages/backend/tests/duplicate-of.test.ts
+++ b/packages/backend/tests/duplicate-of.test.ts
@@ -26,8 +26,10 @@ interface ApiKnowledgeItem {
 let app: Hono;
 let getDb: () => Database.Database;
 let closeDb: () => void;
+let originalFetch: typeof globalThis.fetch;
 
 before(async () => {
+  originalFetch = globalThis.fetch;
   const routesModule = await import("../src/routes.ts");
   const dbModule = await import("../src/db.ts");
 
@@ -40,16 +42,49 @@ before(async () => {
 });
 
 afterEach(() => {
+  globalThis.fetch = originalFetch;
   const db = getDb();
   db.exec("DELETE FROM knowledge; DELETE FROM api_keys;");
+  delete process.env.EMBEDDING_API_KEY;
+  delete process.env.EMBEDDING_API_BASE;
+  delete process.env.EMBEDDING_MODEL;
+  delete process.env.TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD;
+  delete process.env.TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD;
 });
 
 after(() => {
+  globalThis.fetch = originalFetch;
   closeDb();
   rmSync(tempDir, { recursive: true, force: true });
   delete process.env.TEAM_MEMORY_DB;
   delete process.env.TEAM_MEMORY_STALE_AFTER_DAYS;
 });
+
+function encodeEmbedding(vector: number[]): Buffer {
+  return Buffer.from(Float32Array.from(vector).buffer);
+}
+
+function mockEmbeddingResponse(vector: number[]) {
+  process.env.EMBEDDING_API_KEY = "test-duplicate-key";
+  process.env.EMBEDDING_API_BASE = "https://openrouter.ai/api/v1";
+  process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
+
+  globalThis.fetch = (async (_url, init) => {
+    const payload = JSON.parse(String(init?.body));
+    assert.equal(payload.model, "openai/text-embedding-3-small");
+    assert.equal(payload.input.length, 1);
+
+    return new Response(
+      JSON.stringify({
+        data: [{ index: 0, embedding: vector }],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof globalThis.fetch;
+}
 
 function createApiKey(owner = "Tester"): string {
   const db = getDb();
@@ -97,6 +132,7 @@ function insertKnowledgeRow(
     claim: string;
     project?: string;
     duplicateOf?: string | null;
+    embedding?: Buffer | null;
   },
 ): void {
   const now = new Date().toISOString();
@@ -104,8 +140,8 @@ function insertKnowledgeRow(
     `INSERT INTO knowledge (
       id, claim, detail, source, project, module, tags, confidence,
       staleness_hint, owner, related_to, supersedes, superseded_by,
-      duplicate_of, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     input.id,
     input.claim,
@@ -121,12 +157,13 @@ function insertKnowledgeRow(
     null,
     null,
     input.duplicateOf ?? null,
+    input.embedding ?? null,
     now,
     now,
   );
 }
 
-test("fuzzy duplicate warnings do not persist duplicate_of", async () => {
+test("textual fuzzy matches without embeddings do not trigger duplicate warnings", async () => {
   const apiKey = createApiKey();
 
   const original = await publishKnowledge(apiKey, {
@@ -136,8 +173,7 @@ test("fuzzy duplicate warnings do not persist duplicate_of", async () => {
     claim: "Billing pipeline routes usage through Redis buffering before control persistence.",
   });
 
-  assert.equal(fuzzy.warnings?.[0]?.code, "possible_duplicate");
-  assert.equal(fuzzy.warnings?.[0]?.matches[0]?.id, original.id);
+  assert.equal(fuzzy.warnings?.length ?? 0, 0);
   assert.equal(fuzzy.duplicate_of, null);
 
   const stored = getDb()
@@ -157,6 +193,69 @@ test("normalized exact claim matches persist duplicate_of", async () => {
   });
 
   assert.equal(exactDuplicate.duplicate_of, original.id);
+});
+
+test("semantic duplicates trigger warnings even when wording is different", async () => {
+  process.env.TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD = "0.75";
+  process.env.TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD = "0.95";
+
+  const apiKey = createApiKey();
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "semantic-warning-row",
+    claim: "Redis stream buffering protects control-plane persistence.",
+    embedding: encodeEmbedding([0.8, 0.6]),
+  });
+  mockEmbeddingResponse([1, 0]);
+
+  const created = await publishKnowledge(apiKey, {
+    claim: "Usage events are buffered before persistence reaches control services.",
+  });
+
+  assert.equal(created.warnings?.[0]?.code, "possible_duplicate");
+  assert.equal(created.warnings?.[0]?.matches[0]?.id, "semantic-warning-row");
+  assert.equal(created.duplicate_of, null);
+});
+
+test("high semantic similarity persists duplicate_of even without exact text match", async () => {
+  process.env.TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD = "0.75";
+  process.env.TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD = "0.95";
+
+  const apiKey = createApiKey();
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "semantic-persist-row",
+    claim: "Control-plane persistence is protected by Redis stream buffering.",
+    embedding: encodeEmbedding([0.98, 0.2]),
+  });
+  mockEmbeddingResponse([1, 0]);
+
+  const created = await publishKnowledge(apiKey, {
+    claim: "Buffered event delivery protects writes before control-plane persistence.",
+  });
+
+  assert.equal(created.duplicate_of, "semantic-persist-row");
+});
+
+test("unrelated semantic matches do not trigger duplicate warnings", async () => {
+  process.env.TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD = "0.75";
+  process.env.TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD = "0.95";
+
+  const apiKey = createApiKey();
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "unrelated-row",
+    claim: "Billing exports run through a nightly warehouse sync.",
+    embedding: encodeEmbedding([0, 1]),
+  });
+  mockEmbeddingResponse([1, 0]);
+
+  const created = await publishKnowledge(apiKey, {
+    claim: "Buffered event delivery protects writes before control-plane persistence.",
+  });
+
+  assert.equal(created.warnings?.length ?? 0, 0);
+  assert.equal(created.duplicate_of, null);
 });
 
 test("database startup cleanup clears false-positive duplicate_of but preserves exact matches", () => {


### PR DESCRIPTION
## Summary
- replace fuzzy FTS duplicate detection with exact-match-first plus semantic-similarity matching
- persist `duplicate_of` only for normalized exact matches or very high semantic similarity
- document the warning/persist thresholds in `.env.example`

## Validation
- `PATH=/Users/zooey/.nvm/versions/node/v22.22.0/bin:$PATH npm run test --workspace=packages/backend`
- `PATH=/Users/zooey/.nvm/versions/node/v22.22.0/bin:$PATH npm run build --workspace=packages/backend`

## Notes
- exact normalized claim matching still wins over semantic similarity
- semantic warnings and semantic persistence use separate thresholds:
  - `TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD` (default `0.8`)
  - `TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD` (default `0.95`)
- if no embedding is available, duplicate detection degrades cleanly to exact-only behavior
