### PR TITLE
Add reuse tracking and report backend

### DIFF
--- a/packages/backend/src/auth.ts
+++ b/packages/backend/src/auth.ts
@@ -34,6 +34,27 @@ export function requireApiAuth(c: Context): ApiAuth | Response {
   return row;
 }
 
+export function getOptionalApiAuth(c: Context): ApiAuth | Response | null {
+  const header = c.req.header("authorization");
+  if (!header) return null;
+
+  const token = extractBearerToken(header);
+  if (!token) {
+    return jsonError(c, 401, "Missing Authorization: Bearer <api_key> header", "auth_missing");
+  }
+
+  const db = getDb();
+  const row = db
+    .prepare("SELECT key, owner FROM api_keys WHERE key = ? AND revoked_at IS NULL")
+    .get(token) as ApiAuth | undefined;
+
+  if (!row) {
+    return jsonError(c, 401, "Invalid API key", "auth_invalid");
+  }
+
+  return row;
+}
+
 export function requireOwnerAccess(c: Context, itemOwner: string): ApiAuth | Response {
   const auth = requireApiAuth(c);
   if (auth instanceof Response) return auth;

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -79,6 +79,34 @@ export function getDb(): Database.Database {
 
     CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(owner);
     CREATE INDEX IF NOT EXISTS idx_api_keys_revoked_at ON api_keys(revoked_at);
+
+    CREATE TABLE IF NOT EXISTS usage_events (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      knowledge_id  TEXT NOT NULL REFERENCES knowledge(id) ON DELETE CASCADE,
+      owner         TEXT NOT NULL,
+      event_type    TEXT NOT NULL CHECK (event_type IN ('exposure', 'view')),
+      request_id    TEXT,
+      query_context TEXT,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_usage_events_knowledge ON usage_events(knowledge_id);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_owner ON usage_events(owner);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_request ON usage_events(request_id);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_created ON usage_events(created_at);
+
+    CREATE TABLE IF NOT EXISTS reuse_feedback (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      knowledge_id  TEXT NOT NULL REFERENCES knowledge(id) ON DELETE CASCADE,
+      owner         TEXT NOT NULL,
+      verdict       TEXT NOT NULL CHECK (verdict IN ('useful', 'not_useful', 'outdated')),
+      comment       TEXT,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_reuse_feedback_knowledge ON reuse_feedback(knowledge_id);
+    CREATE INDEX IF NOT EXISTS idx_reuse_feedback_owner ON reuse_feedback(owner);
+    CREATE INDEX IF NOT EXISTS idx_reuse_feedback_created ON reuse_feedback(created_at);
   `);
 
   ensureColumn(_db, "knowledge", "duplicate_of", "TEXT");

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { v4 as uuidv4 } from "uuid";
-import { requireApiAuth, requireOwnerAccess } from "./auth.js";
+import { getOptionalApiAuth, requireApiAuth, requireOwnerAccess } from "./auth.js";
 import { getDb } from "./db.js";
 import { findPersistedDuplicateOf } from "./duplicates.js";
 import { embedKnowledgeItem, embedTexts } from "./embedding.js";
@@ -22,6 +22,7 @@ interface SemanticKnowledgeRow extends KnowledgeRow {
 }
 
 type SearchMode = "fts" | "semantic" | "hybrid";
+type ReuseVerdict = "useful" | "not_useful" | "outdated";
 
 // Prefer semantic signal, but give a small bonus when a row matches both worlds.
 const HYBRID_FTS_WEIGHT = 0.35;
@@ -160,6 +161,42 @@ async function runSemanticCandidates(
 }
 
 const VALID_CONFIDENCE = new Set(["high", "medium", "low"]);
+const VALID_REUSE_VERDICTS = new Set<ReuseVerdict>(["useful", "not_useful", "outdated"]);
+
+function recordExposureEvents(
+  db: ReturnType<typeof getDb>,
+  owner: string,
+  knowledgeIds: string[],
+  queryContext: string,
+): void {
+  if (knowledgeIds.length === 0) return;
+
+  const requestId = uuidv4();
+  const insert = db.prepare(
+    `INSERT INTO usage_events (knowledge_id, owner, event_type, request_id, query_context)
+     VALUES (?, ?, 'exposure', ?, ?)`,
+  );
+
+  const transaction = db.transaction((ids: string[]) => {
+    for (const knowledgeId of ids) {
+      insert.run(knowledgeId, owner, requestId, queryContext);
+    }
+  });
+
+  transaction(knowledgeIds);
+}
+
+function recordViewEvent(
+  db: ReturnType<typeof getDb>,
+  owner: string,
+  knowledgeId: string,
+  queryContext: string | null,
+): void {
+  db.prepare(
+    `INSERT INTO usage_events (knowledge_id, owner, event_type, request_id, query_context)
+     VALUES (?, ?, 'view', NULL, ?)`,
+  ).run(knowledgeId, owner, queryContext);
+}
 
 // 1. POST /api/knowledge
 api.post("/knowledge", async (c) => {
@@ -224,6 +261,8 @@ api.post("/knowledge", async (c) => {
 api.get("/knowledge/search", async (c) => {
   const q = c.req.query("q");
   if (!q) return c.json({ error: "Query parameter 'q' is required" }, 400);
+  const maybeAuth = getOptionalApiAuth(c);
+  if (maybeAuth instanceof Response) return maybeAuth;
   const project = c.req.query("project");
   const tags = c.req.query("tags");
   const module_ = c.req.query("module");
@@ -297,6 +336,10 @@ api.get("/knowledge/search", async (c) => {
     .slice(0, limit)
     .map(({ hybrid_score: _hybridScore, fts_score: _ftsScore, semantic_score: _semanticScore, ...item }) => item);
 
+  if (maybeAuth) {
+    recordExposureEvents(db, maybeAuth.owner, items.map((item) => item.id), q);
+  }
+
   return c.json({ items, total: merged.size });
 });
 
@@ -304,6 +347,8 @@ api.get("/knowledge/search", async (c) => {
 api.get("/knowledge/semantic-search", async (c) => {
   const q = c.req.query("q");
   if (!q) return c.json({ error: "Query parameter 'q' is required" }, 400);
+  const maybeAuth = getOptionalApiAuth(c);
+  if (maybeAuth instanceof Response) return maybeAuth;
 
   const project = c.req.query("project");
   const limit = Math.min(parseInt(c.req.query("limit") ?? "10", 10) || 10, 100);
@@ -338,10 +383,12 @@ api.get("/knowledge/semantic-search", async (c) => {
     .filter((row): row is ReturnType<typeof summaryFromRow> & { similarity: number } => row !== null)
     .sort((left, right) => right.similarity - left.similarity);
 
-  return c.json({
-    items: ranked.slice(0, limit),
-    total: ranked.length,
-  });
+  const items = ranked.slice(0, limit);
+  if (maybeAuth) {
+    recordExposureEvents(db, maybeAuth.owner, items.map((item) => item.id), q);
+  }
+
+  return c.json({ items, total: ranked.length });
 });
 
 // 4. GET /api/knowledge
@@ -376,10 +423,197 @@ api.get("/knowledge/:id", (c) => {
   const db = getDb();
   const row = db.prepare("SELECT * FROM knowledge WHERE id = ?").get(c.req.param("id")) as KnowledgeRow | undefined;
   if (!row) return c.json({ error: "Knowledge item not found" }, 404);
+  const maybeAuth = getOptionalApiAuth(c);
+  if (maybeAuth instanceof Response) return maybeAuth;
+  if (maybeAuth) {
+    recordViewEvent(db, maybeAuth.owner, row.id, c.req.query("query_context") ?? null);
+  }
   return c.json(rowToJson(row));
 });
 
-// 6. PATCH /api/knowledge/:id
+// 6. GET /api/reports/reuse
+api.get("/reports/reuse", (c) => {
+  const db = getDb();
+  const knowledgeRows = db.prepare(
+    "SELECT id, claim, created_at FROM knowledge ORDER BY created_at ASC",
+  ).all() as Array<{ id: string; claim: string; created_at: string }>;
+  const usageRows = db.prepare(
+    "SELECT knowledge_id, owner, event_type, request_id FROM usage_events",
+  ).all() as Array<{
+    knowledge_id: string;
+    owner: string;
+    event_type: "exposure" | "view";
+    request_id: string | null;
+  }>;
+  const feedbackRows = db.prepare(
+    "SELECT knowledge_id, owner, verdict FROM reuse_feedback",
+  ).all() as Array<{
+    knowledge_id: string;
+    owner: string;
+    verdict: ReuseVerdict;
+  }>;
+
+  const stats = new Map<string, {
+    claim: string;
+    exposure_count: number;
+    view_count: number;
+    view_owners: Set<string>;
+    useful_owners: Set<string>;
+    useful_feedback_count: number;
+    not_useful_feedback_count: number;
+    outdated_feedback_count: number;
+  }>();
+
+  for (const row of knowledgeRows) {
+    stats.set(row.id, {
+      claim: row.claim,
+      exposure_count: 0,
+      view_count: 0,
+      view_owners: new Set<string>(),
+      useful_owners: new Set<string>(),
+      useful_feedback_count: 0,
+      not_useful_feedback_count: 0,
+      outdated_feedback_count: 0,
+    });
+  }
+
+  const queryIds = new Set<string>();
+  for (const row of usageRows) {
+    const item = stats.get(row.knowledge_id);
+    if (!item) continue;
+
+    if (row.event_type === "exposure") {
+      item.exposure_count += 1;
+      if (row.request_id) queryIds.add(row.request_id);
+      continue;
+    }
+
+    item.view_count += 1;
+    item.view_owners.add(row.owner);
+  }
+
+  for (const row of feedbackRows) {
+    const item = stats.get(row.knowledge_id);
+    if (!item) continue;
+
+    if (row.verdict === "useful") {
+      item.useful_feedback_count += 1;
+      item.useful_owners.add(row.owner);
+    } else if (row.verdict === "not_useful") {
+      item.not_useful_feedback_count += 1;
+    } else {
+      item.outdated_feedback_count += 1;
+    }
+  }
+
+  const totalItems = knowledgeRows.length;
+  const neverAccessed = knowledgeRows
+    .filter((row) => {
+      const item = stats.get(row.id);
+      if (!item) return false;
+      return (
+        item.exposure_count === 0
+        && item.view_count === 0
+        && item.useful_feedback_count === 0
+        && item.not_useful_feedback_count === 0
+        && item.outdated_feedback_count === 0
+      );
+    })
+    .map((row) => ({ id: row.id, claim: row.claim }));
+
+  const northStarCount = knowledgeRows.filter((row) => {
+    const item = stats.get(row.id);
+    if (!item) return false;
+
+    const owners = new Set<string>([
+      ...item.view_owners,
+      ...item.useful_owners,
+    ]);
+    return owners.size >= 2;
+  }).length;
+
+  const topReused = knowledgeRows
+    .map((row) => {
+      const item = stats.get(row.id)!;
+      const uniqueOwners = new Set<string>([
+        ...item.view_owners,
+        ...item.useful_owners,
+      ]);
+      return {
+        knowledge_id: row.id,
+        claim: row.claim,
+        view_count: item.view_count,
+        unique_owners: uniqueOwners.size,
+        useful_feedback_count: item.useful_feedback_count,
+        not_useful_feedback_count: item.not_useful_feedback_count,
+        outdated_feedback_count: item.outdated_feedback_count,
+        reuse_score: item.view_count + item.useful_feedback_count,
+      };
+    })
+    .filter((item) => item.reuse_score > 0)
+    .sort((left, right) => {
+      if (right.reuse_score !== left.reuse_score) {
+        return right.reuse_score - left.reuse_score;
+      }
+      if (right.unique_owners !== left.unique_owners) {
+        return right.unique_owners - left.unique_owners;
+      }
+      return left.claim.localeCompare(right.claim);
+    })
+    .slice(0, 10)
+    .map(({ reuse_score: _reuseScore, ...item }) => item);
+
+  const neverAccessedPct = totalItems === 0 ? 0 : neverAccessed.length / totalItems;
+  const northStar = totalItems === 0 ? 0 : northStarCount / totalItems;
+
+  return c.json({
+    total_queries: queryIds.size,
+    total_views: usageRows.filter((row) => row.event_type === "view").length,
+    total_items: totalItems,
+    never_accessed_pct: neverAccessedPct,
+    north_star: northStar,
+    top_reused: topReused,
+    never_accessed: neverAccessed,
+  });
+});
+
+// 7. POST /api/knowledge/:id/feedback
+api.post("/knowledge/:id/feedback", async (c) => {
+  const id = c.req.param("id");
+  const db = getDb();
+  const row = db.prepare("SELECT id FROM knowledge WHERE id = ?").get(id) as { id: string } | undefined;
+  if (!row) return c.json({ error: "Knowledge item not found" }, 404);
+
+  const auth = requireApiAuth(c);
+  if (auth instanceof Response) return auth;
+
+  const body = await c.req.json();
+  const verdict = body.verdict as ReuseVerdict | undefined;
+  const comment = body.comment;
+
+  if (!verdict || !VALID_REUSE_VERDICTS.has(verdict)) {
+    return c.json({ error: "verdict must be one of: useful, not_useful, outdated" }, 400);
+  }
+  if (comment !== undefined && comment !== null && typeof comment !== "string") {
+    return c.json({ error: "comment must be a string when provided" }, 400);
+  }
+
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO reuse_feedback (knowledge_id, owner, verdict, comment, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(id, auth.owner, verdict, comment ?? null, now);
+
+  return c.json({
+    knowledge_id: id,
+    owner: auth.owner,
+    verdict,
+    comment: comment ?? null,
+    created_at: now,
+  }, 201);
+});
+
+// 8. PATCH /api/knowledge/:id
 api.patch("/knowledge/:id", async (c) => {
   const id = c.req.param("id");
   const body = await c.req.json();

--- a/packages/backend/tests/reuse-report.test.ts
+++ b/packages/backend/tests/reuse-report.test.ts
@@ -1,0 +1,269 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-reuse-report-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+
+interface NeverAccessedItem {
+  id: string;
+  claim: string;
+}
+
+interface TopReusedItem {
+  knowledge_id: string;
+  claim: string;
+  view_count: number;
+  unique_owners: number;
+  useful_feedback_count: number;
+  not_useful_feedback_count: number;
+  outdated_feedback_count: number;
+}
+
+interface ReuseReportResponse {
+  total_queries: number;
+  total_views: number;
+  total_items: number;
+  never_accessed_pct: number;
+  north_star: number;
+  top_reused: TopReusedItem[];
+  never_accessed: NeverAccessedItem[];
+}
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    claim: string;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim,
+    null,
+    JSON.stringify(["tests/reuse-report.test.ts"]),
+    "team-memory",
+    "reuse-report",
+    JSON.stringify(["reuse"]),
+    "high",
+    "Recheck if reuse-report semantics change.",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    null,
+    null,
+    null,
+    now,
+    now,
+  );
+}
+
+function insertUsageEvent(
+  db: Database.Database,
+  input: {
+    knowledgeId: string;
+    owner: string;
+    eventType: "exposure" | "view";
+    requestId?: string | null;
+    queryContext?: string | null;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO usage_events (knowledge_id, owner, event_type, request_id, query_context)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    input.knowledgeId,
+    input.owner,
+    input.eventType,
+    input.requestId ?? null,
+    input.queryContext ?? null,
+  );
+}
+
+function insertFeedback(
+  db: Database.Database,
+  input: {
+    knowledgeId: string;
+    owner: string;
+    verdict: "useful" | "not_useful" | "outdated";
+    comment?: string | null;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO reuse_feedback (knowledge_id, owner, verdict, comment)
+     VALUES (?, ?, ?, ?)`,
+  ).run(
+    input.knowledgeId,
+    input.owner,
+    input.verdict,
+    input.comment ?? null,
+  );
+}
+
+before(async () => {
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+});
+
+afterEach(() => {
+  const db = getDb();
+  db.exec("DELETE FROM reuse_feedback; DELETE FROM usage_events; DELETE FROM knowledge; DELETE FROM api_keys;");
+});
+
+after(() => {
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.TEAM_MEMORY_DB;
+});
+
+test("reuse report aggregates total queries, views, north-star, top reused, and never-accessed items", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "item-a", claim: "Billing writes belong to the control plane." });
+  insertKnowledgeRow(db, { id: "item-b", claim: "Usage events are mirrored before persistence." });
+  insertKnowledgeRow(db, { id: "item-c", claim: "Never accessed item C." });
+  insertKnowledgeRow(db, { id: "item-d", claim: "Never accessed item D." });
+
+  insertUsageEvent(db, {
+    knowledgeId: "item-a",
+    owner: "Alice",
+    eventType: "exposure",
+    requestId: "request-1",
+    queryContext: "billing ownership",
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "item-b",
+    owner: "Alice",
+    eventType: "exposure",
+    requestId: "request-1",
+    queryContext: "billing ownership",
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "item-a",
+    owner: "Bob",
+    eventType: "exposure",
+    requestId: "request-2",
+    queryContext: "usage persistence",
+  });
+
+  insertUsageEvent(db, {
+    knowledgeId: "item-a",
+    owner: "Alice",
+    eventType: "view",
+    queryContext: "billing ownership",
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "item-a",
+    owner: "Bob",
+    eventType: "view",
+    queryContext: "usage persistence",
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "item-b",
+    owner: "Alice",
+    eventType: "view",
+    queryContext: "billing ownership",
+  });
+
+  insertFeedback(db, {
+    knowledgeId: "item-a",
+    owner: "Bob",
+    verdict: "useful",
+    comment: "Saved time.",
+  });
+  insertFeedback(db, {
+    knowledgeId: "item-b",
+    owner: "Alice",
+    verdict: "not_useful",
+  });
+  insertFeedback(db, {
+    knowledgeId: "item-b",
+    owner: "Carol",
+    verdict: "outdated",
+  });
+
+  const response = await app.request("http://localhost/api/reports/reuse");
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as ReuseReportResponse;
+
+  assert.equal(body.total_queries, 2);
+  assert.equal(body.total_views, 3);
+  assert.equal(body.total_items, 4);
+  assert.equal(body.never_accessed_pct, 0.5);
+  assert.equal(body.north_star, 0.25);
+  assert.deepEqual(
+    body.top_reused.map((item) => ({
+      knowledge_id: item.knowledge_id,
+      view_count: item.view_count,
+      unique_owners: item.unique_owners,
+      useful_feedback_count: item.useful_feedback_count,
+      not_useful_feedback_count: item.not_useful_feedback_count,
+      outdated_feedback_count: item.outdated_feedback_count,
+    })),
+    [
+      {
+        knowledge_id: "item-a",
+        view_count: 2,
+        unique_owners: 2,
+        useful_feedback_count: 1,
+        not_useful_feedback_count: 0,
+        outdated_feedback_count: 0,
+      },
+      {
+        knowledge_id: "item-b",
+        view_count: 1,
+        unique_owners: 1,
+        useful_feedback_count: 0,
+        not_useful_feedback_count: 1,
+        outdated_feedback_count: 1,
+      },
+    ],
+  );
+  assert.deepEqual(
+    body.never_accessed.map((item) => item.id),
+    ["item-c", "item-d"],
+  );
+});
+
+test("reuse report returns zeroed metrics when there is no usage data", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "lonely-item", claim: "This item has never been accessed." });
+
+  const response = await app.request("http://localhost/api/reports/reuse");
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as ReuseReportResponse;
+
+  assert.equal(body.total_queries, 0);
+  assert.equal(body.total_views, 0);
+  assert.equal(body.total_items, 1);
+  assert.equal(body.never_accessed_pct, 1);
+  assert.equal(body.north_star, 0);
+  assert.deepEqual(body.top_reused, []);
+  assert.deepEqual(body.never_accessed, [{ id: "lonely-item", claim: "This item has never been accessed." }]);
+});

--- a/packages/backend/tests/reuse-tracking.test.ts
+++ b/packages/backend/tests/reuse-tracking.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-reuse-tracking-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+process.env.EMBEDDING_API_KEY = "test-reuse-key";
+process.env.EMBEDDING_API_BASE = "https://openrouter.ai/api/v1";
+process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
+
+interface UsageEventRow {
+  knowledge_id: string;
+  owner: string;
+  event_type: string;
+  request_id: string | null;
+  query_context: string | null;
+}
+
+interface ReuseFeedbackRow {
+  knowledge_id: string;
+  owner: string;
+  verdict: string;
+  comment: string | null;
+}
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+let originalFetch: typeof globalThis.fetch;
+
+function encodeEmbedding(vector: number[]): Buffer {
+  return Buffer.from(Float32Array.from(vector).buffer);
+}
+
+function createApiKey(owner = "Tester"): string {
+  const db = getDb();
+  const key = `${owner.toLowerCase()}-key`;
+  db.prepare(
+    "INSERT OR REPLACE INTO api_keys (key, owner, created_at, revoked_at) VALUES (?, ?, ?, NULL)",
+  ).run(key, owner, new Date().toISOString());
+  return key;
+}
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    claim: string;
+    project?: string;
+    embedding?: Buffer | null;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim,
+    null,
+    JSON.stringify(["tests/reuse-tracking.test.ts"]),
+    input.project ?? "team-memory",
+    "reuse",
+    JSON.stringify(["reuse"]),
+    "high",
+    "Recheck if reuse tracking semantics change.",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    null,
+    null,
+    input.embedding ?? null,
+    now,
+    now,
+  );
+}
+
+before(async () => {
+  originalFetch = globalThis.fetch;
+
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  const db = getDb();
+  db.exec("DELETE FROM knowledge; DELETE FROM api_keys;");
+  db.exec("DELETE FROM usage_events; DELETE FROM reuse_feedback;");
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.TEAM_MEMORY_DB;
+  delete process.env.EMBEDDING_API_KEY;
+  delete process.env.EMBEDDING_API_BASE;
+  delete process.env.EMBEDDING_MODEL;
+});
+
+test("authenticated FTS search writes exposure events with a shared request_id", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "billing-row-a",
+    claim: "Billing pipeline buffers usage events before persistence.",
+  });
+  insertKnowledgeRow(db, {
+    id: "billing-row-b",
+    claim: "Billing ownership stays in the control plane.",
+  });
+  const apiKey = createApiKey("Researcher");
+
+  const response = await app.request("http://localhost/api/knowledge/search?q=billing", {
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  assert.equal(response.status, 200);
+
+  const events = getDb().prepare(
+    "SELECT knowledge_id, owner, event_type, request_id, query_context FROM usage_events ORDER BY knowledge_id ASC",
+  ).all() as UsageEventRow[];
+
+  assert.equal(events.length, 2);
+  assert.deepEqual(events.map((event) => event.knowledge_id), ["billing-row-a", "billing-row-b"]);
+  assert.ok(events[0]!.request_id);
+  assert.equal(events[0]!.request_id, events[1]!.request_id);
+  assert.deepEqual(
+    events.map((event) => ({
+      owner: event.owner,
+      event_type: event.event_type,
+      query_context: event.query_context,
+    })),
+    [
+      { owner: "Researcher", event_type: "exposure", query_context: "billing" },
+      { owner: "Researcher", event_type: "exposure", query_context: "billing" },
+    ],
+  );
+});
+
+test("authenticated semantic search writes exposure events with query context", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "semantic-row",
+    claim: "Inference usage events are mirrored before billing persistence.",
+    embedding: encodeEmbedding([1, 0]),
+  });
+  const apiKey = createApiKey("SemanticUser");
+
+  globalThis.fetch = (async () => new Response(
+    JSON.stringify({
+      data: [{ index: 0, embedding: [1, 0] }],
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    },
+  )) as typeof globalThis.fetch;
+
+  const response = await app.request("http://localhost/api/knowledge/semantic-search?q=usage%20mirroring", {
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  assert.equal(response.status, 200);
+
+  const events = getDb().prepare(
+    "SELECT knowledge_id, owner, event_type, request_id, query_context FROM usage_events",
+  ).all() as UsageEventRow[];
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.knowledge_id, "semantic-row");
+  assert.equal(events[0]!.owner, "SemanticUser");
+  assert.equal(events[0]!.event_type, "exposure");
+  assert.ok(events[0]!.request_id);
+  assert.equal(events[0]!.query_context, "usage mirroring");
+});
+
+test("authenticated get_knowledge writes a view event and stores query_context", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "view-row",
+    claim: "Control plane owns billing writes.",
+  });
+  const apiKey = createApiKey("Viewer");
+
+  const response = await app.request(
+    "http://localhost/api/knowledge/view-row?query_context=task%3Abilling-investigation",
+    {
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+
+  const event = getDb().prepare(
+    "SELECT knowledge_id, owner, event_type, request_id, query_context FROM usage_events",
+  ).get() as UsageEventRow;
+
+  assert.equal(event.knowledge_id, "view-row");
+  assert.equal(event.owner, "Viewer");
+  assert.equal(event.event_type, "view");
+  assert.equal(event.request_id, null);
+  assert.equal(event.query_context, "task:billing-investigation");
+});
+
+test("authenticated feedback endpoint persists reuse feedback", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "feedback-row",
+    claim: "Knowledge reuse should be measurable.",
+  });
+  const apiKey = createApiKey("Reviewer");
+
+  const response = await app.request("http://localhost/api/knowledge/feedback-row/feedback", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      verdict: "useful",
+      comment: "Saved the first round of research.",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+
+  const row = getDb().prepare(
+    "SELECT knowledge_id, owner, verdict, comment FROM reuse_feedback",
+  ).get() as ReuseFeedbackRow;
+
+  assert.equal(row.knowledge_id, "feedback-row");
+  assert.equal(row.owner, "Reviewer");
+  assert.equal(row.verdict, "useful");
+  assert.equal(row.comment, "Saved the first round of research.");
+});


### PR DESCRIPTION
## Summary
- add backend reuse-tracking infrastructure for exposure/view events and explicit reuse feedback
- add `/api/reports/reuse` aggregation endpoint for P0 metrics and dashboard consumption
- keep read endpoints publicly usable while logging agent usage when a valid API key is present

## What changed
- schema:
  - `usage_events` with `knowledge_id TEXT`, `event_type` (`exposure` / `view`), `request_id`, `query_context`
  - `reuse_feedback`
- auth:
  - optional read-auth helper so authenticated agent reads can be logged without forcing auth on every read request
- routes:
  - authenticated search + semantic-search write `exposure` events
  - authenticated `get /api/knowledge/:id` writes `view` events with optional `query_context`
  - new `POST /api/knowledge/:id/feedback`
  - new `GET /api/reports/reuse`
- tests:
  - added `reuse-tracking.test.ts`
  - added `reuse-report.test.ts`

## Metrics in `/api/reports/reuse`
- `total_queries`
- `total_views`
- `total_items`
- `never_accessed_pct`
- `north_star`
- `top_reused`
- `never_accessed`

Per team decision in thread `#hackathon:d6fa5fa5`, P0 does **not** include `hit_rate` yet because zero-hit queries are not observable with the current schema.

## Validation
- `PATH=/Users/zooey/.nvm/versions/node/v22.22.0/bin:$PATH npm run test --workspace=packages/backend`
- `PATH=/Users/zooey/.nvm/versions/node/v22.22.0/bin:$PATH npm run build --workspace=packages/backend`
