### PR TITLE
feat(mcp): add reuse_feedback tool + query_context on get_knowledge

### DIFF
--- a/packages/mcp-server/src/api-client.ts
+++ b/packages/mcp-server/src/api-client.ts
@@ -76,6 +76,22 @@ export interface UpdateInput {
   confidence?: "high" | "medium" | "low";
 }
 
+export type ReuseVerdict = "useful" | "not_useful" | "outdated";
+
+export interface ReuseFeedbackInput {
+  knowledge_id: string;
+  verdict: ReuseVerdict;
+  comment?: string;
+}
+
+export interface ReuseFeedback {
+  knowledge_id: string;
+  owner: string;
+  verdict: ReuseVerdict;
+  comment: string | null;
+  created_at: string;
+}
+
 export class ApiClient {
   private baseUrl: string;
   private apiKey?: string;
@@ -85,12 +101,12 @@ export class ApiClient {
     this.apiKey = apiKey;
   }
 
+  private authHeaders(): Record<string, string> {
+    return this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {};
+  }
+
   private writeHeaders(): Record<string, string> {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (this.apiKey) {
-      headers["Authorization"] = `Bearer ${this.apiKey}`;
-    }
-    return headers;
+    return { "Content-Type": "application/json", ...this.authHeaders() };
   }
 
   async publish(input: PublishInput): Promise<KnowledgeItem> {
@@ -115,7 +131,8 @@ export class ApiClient {
     if (input.limit) params.set("limit", String(input.limit));
 
     const res = await fetch(
-      `${this.baseUrl}/api/knowledge/search?${params.toString()}`
+      `${this.baseUrl}/api/knowledge/search?${params.toString()}`,
+      { headers: this.authHeaders() }
     );
     if (!res.ok) {
       const text = await res.text();
@@ -132,7 +149,8 @@ export class ApiClient {
     if (input.limit) params.set("limit", String(input.limit));
 
     const res = await fetch(
-      `${this.baseUrl}/api/knowledge?${params.toString()}`
+      `${this.baseUrl}/api/knowledge?${params.toString()}`,
+      { headers: this.authHeaders() }
     );
     if (!res.ok) {
       const text = await res.text();
@@ -142,13 +160,35 @@ export class ApiClient {
     return data.items;
   }
 
-  async get(id: string): Promise<KnowledgeItem> {
-    const res = await fetch(`${this.baseUrl}/api/knowledge/${id}`);
+  async get(id: string, queryContext?: string): Promise<KnowledgeItem> {
+    const params = new URLSearchParams();
+    if (queryContext) params.set("query_context", queryContext);
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    const res = await fetch(`${this.baseUrl}/api/knowledge/${id}${suffix}`, {
+      headers: this.authHeaders(),
+    });
     if (!res.ok) {
       const text = await res.text();
       throw new Error(`get failed (${res.status}): ${text}`);
     }
     return res.json() as Promise<KnowledgeItem>;
+  }
+
+  async reuseFeedback(input: ReuseFeedbackInput): Promise<ReuseFeedback> {
+    const { knowledge_id, ...body } = input;
+    const res = await fetch(
+      `${this.baseUrl}/api/knowledge/${knowledge_id}/feedback`,
+      {
+        method: "POST",
+        headers: this.writeHeaders(),
+        body: JSON.stringify(body),
+      }
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`reuse feedback failed (${res.status}): ${text}`);
+    }
+    return res.json() as Promise<ReuseFeedback>;
   }
 
   async semanticSearch(input: SemanticSearchInput): Promise<KnowledgeSummary[]> {
@@ -158,7 +198,8 @@ export class ApiClient {
     if (input.limit) params.set("limit", String(input.limit));
 
     const res = await fetch(
-      `${this.baseUrl}/api/knowledge/semantic-search?${params.toString()}`
+      `${this.baseUrl}/api/knowledge/semantic-search?${params.toString()}`,
+      { headers: this.authHeaders() }
     );
     if (!res.ok) {
       const text = await res.text();

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -127,13 +127,14 @@ server.tool(
 // --- Tool 5: get_knowledge ---
 server.tool(
   "get_knowledge",
-  "Get the full content of a single knowledge item by ID. Use this after query/list to read the complete detail.",
+  "Get the full content of a single knowledge item by ID. Use this after query/list to read the complete detail. Opening an item records a 'view' event for reuse tracking — pass query_context to tag what task or question prompted the view.",
   {
     id: z.string().describe("The knowledge item UUID"),
+    query_context: z.string().optional().describe("What task or question prompted this view (optional). Gets attached to the view event so reports can show why each item was opened."),
   },
   async (args) => {
     try {
-      const item = await client.get(args.id);
+      const item = await client.get(args.id, args.query_context);
       const parts = [
         `**${item.claim}**`, "",
         item.detail ?? "(no detail)", "",
@@ -157,7 +158,31 @@ server.tool(
   }
 );
 
-// --- Tool 6: update_knowledge ---
+// --- Tool 6: reuse_feedback ---
+server.tool(
+  "reuse_feedback",
+  "Report whether a knowledge item was actually useful after using it. Call this after get_knowledge once you know whether the content helped. Verdict: 'useful' (it answered my question or saved work), 'not_useful' (irrelevant or wrong), 'outdated' (used to be true but no longer applies). This feeds the team's reuse metrics.",
+  {
+    knowledge_id: z.string().describe("The knowledge item UUID you are giving feedback on"),
+    verdict: z.enum(["useful", "not_useful", "outdated"]).describe("useful = it helped / saved me work; not_useful = irrelevant or wrong; outdated = used to be true but no longer applies"),
+    comment: z.string().optional().describe("Optional one-line note (e.g. what was wrong, or how you used it)"),
+  },
+  async (args) => {
+    try {
+      const feedback = await client.reuseFeedback(args);
+      return {
+        content: [{
+          type: "text" as const,
+          text: `Feedback recorded.\n\nKnowledge ID: ${feedback.knowledge_id}\nVerdict: ${feedback.verdict}${feedback.comment ? `\nComment: ${feedback.comment}` : ""}\nRecorded by: ${feedback.owner}\nAt: ${feedback.created_at}`,
+        }],
+      };
+    } catch (err) {
+      return { content: [{ type: "text" as const, text: `Error: ${err}` }], isError: true };
+    }
+  }
+);
+
+// --- Tool 7: update_knowledge ---
 server.tool(
   "update_knowledge",
   "Update metadata of an existing knowledge item. Only tags, staleness_hint, related_to, and confidence can be changed. To change the claim itself, publish a new item with supersedes.",


### PR DESCRIPTION
## Summary
- Adds `reuse_feedback` MCP tool so agents can report `useful` / `not_useful` / `outdated` after using a knowledge item, closing the team reuse measurement loop (P0 M2).
- Adds optional `query_context` parameter to `get_knowledge`, forwarded to the backend `view` event so reports can show why each item was opened.
- Sends the `Authorization` header on read endpoints (`query_knowledge`, `semantic_search`, `list_knowledge`, `get_knowledge`) so the backend can attribute `exposure` / `view` events to the calling agent.

Closes #37 (MCP + client-side). Docs (agent-protocol.md, mcp-config-template.md) handled by @Spike in a follow-up per PM plan.

## Test plan
- [x] `npm run build --workspace=packages/mcp-server` succeeds
- [ ] @Ein: verify contract matches PR #26 (`POST /api/knowledge/:id/feedback` body + response, `GET /api/knowledge/:id?query_context=...` behavior)
- [ ] Manual smoke test: publish → query → get_knowledge(with query_context) → reuse_feedback → check `GET /api/reports/reuse` reflects the activity
- [ ] @Jet: review tool descriptions for UUID wording + query / exposure / view / feedback term alignment once @Spike's docs PR is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)