### PR TITLE
docs(p0): add reuse tracking semantics to agent protocol

### DIFF
--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -2,6 +2,21 @@
 
 This document defines how agents should interact with Team Memory in their daily workflows. The goal is simple: **no agent should redo work that another agent already published**.
 
+## How Team Memory Measures Reuse
+
+Every interaction with a knowledge item is recorded so we can tell whether the system is actually saving work. The model uses four distinct event types — learn these names, they show up in tool descriptions, reports, and the dashboard.
+
+| Event | How it's produced | What it means |
+|-------|-------------------|---------------|
+| **query** | You call `query_knowledge` or `semantic_search` | You asked the team's memory a question |
+| **exposure** | An item appeared in your search results | The item was offered to you but you may not have opened it |
+| **view** | You call `get_knowledge` on an item | You opened the full detail — a weak reuse signal |
+| **feedback** | You call `reuse_feedback` with a verdict | You explicitly told the system whether the item helped — the strong reuse signal |
+
+Reports prioritize `view` + `feedback` over `exposure` for the real reuse metrics (north star, top reused). Exposure is tracked for search-effectiveness analysis only.
+
+**Practical takeaway:** every `get_knowledge` should be followed by a `reuse_feedback` once you know whether it helped. Without feedback, the team only sees weak signals.
+
 ## Core Workflow
 
 ### 1. Query Before Work
@@ -16,13 +31,35 @@ semantic_search({ query: "<natural language description of your task>", project:
 - `query_knowledge` uses keyword matching (FTS5) — best for exact terms, function names, error messages.
 - `semantic_search` uses vector similarity — best for conceptual queries where the exact words may differ.
 
-If results are found, read the full item:
+If results are found, read the full item and tag what you were doing so reuse can be measured:
 
 ```
-get_knowledge({ id: "<matched-id>" })
+get_knowledge({ id: "<matched-id>", query_context: "<task or question you're working on>" })
 ```
+
+- `query_context` is optional but strongly recommended. It attaches a label to the `view` event so reports can show **why** each item was opened (e.g. `"task #42: billing refund investigation"`).
 
 Use existing knowledge as context. Skip analysis that has already been done. If the existing knowledge is outdated, supersede it (see below).
+
+### Give Reuse Feedback
+
+After you finish using a knowledge item, tell the system whether it helped:
+
+```
+reuse_feedback({
+  knowledge_id: "<matched-id>",
+  verdict: "useful" | "not_useful" | "outdated",
+  comment: "<optional one-line note>"
+})
+```
+
+| verdict | When to use |
+|---------|-------------|
+| `useful` | It answered your question or saved you work |
+| `not_useful` | Irrelevant to your task, or the claim turned out to be wrong |
+| `outdated` | Used to be true but no longer applies (consider also publishing a superseding item) |
+
+Feedback is how the team knows which items are worth keeping. **Skipping this is the single biggest reason metrics go stale.** Treat `reuse_feedback` as mandatory when you open an item, not as optional.
 
 ### 2. Publish After Work
 
@@ -130,13 +167,23 @@ query_knowledge({ query: "billing refund", project: "infer-monorepo" })
 # Step 1b: Also try semantic search for broader matches
 semantic_search({ query: "how are refunds processed in the billing system", project: "infer-monorepo" })
 
-# Step 2: Found relevant item, read full detail
-get_knowledge({ id: "abc-123" })
+# Step 2: Found relevant item, read full detail with query_context
+get_knowledge({
+  id: "abc-123",
+  query_context: "investigating refund webhook signature validation"
+})
 
 # Step 3: Use that context in your work, skip re-analysis
 # ...do the task...
 
-# Step 4: Publish your new finding
+# Step 4: Tell the system whether abc-123 actually helped
+reuse_feedback({
+  knowledge_id: "abc-123",
+  verdict: "useful",
+  comment: "Confirmed webhook handler path, saved a round of tracing"
+})
+
+# Step 5: Publish your new finding
 publish_knowledge({
   claim: "Refund webhook handler in billing/webhooks.ts does not validate event signatures",
   source: ["billing/webhooks.ts:42-58"],

--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -4,14 +4,16 @@ This document defines how agents should interact with Team Memory in their daily
 
 ## How Team Memory Measures Reuse
 
-Every interaction with a knowledge item is recorded so we can tell whether the system is actually saving work. The model uses four distinct event types — learn these names, they show up in tool descriptions, reports, and the dashboard.
+Every interaction with a knowledge item is recorded so we can tell whether the system is actually saving work. The model uses four terms — learn these names, they show up in tool descriptions, reports, and the dashboard.
 
-| Event | How it's produced | What it means |
-|-------|-------------------|---------------|
-| **query** | You call `query_knowledge` or `semantic_search` | You asked the team's memory a question |
-| **exposure** | An item appeared in your search results | The item was offered to you but you may not have opened it |
-| **view** | You call `get_knowledge` on an item | You opened the full detail — a weak reuse signal |
-| **feedback** | You call `reuse_feedback` with a verdict | You explicitly told the system whether the item helped — the strong reuse signal |
+| Term | How it's produced | What it means |
+|------|-------------------|---------------|
+| **query** | You call `query_knowledge` or `semantic_search`. Derived, not stored directly — counted as `COUNT(DISTINCT request_id)` over exposure rows | You asked the team's memory a question |
+| **exposure** | An `exposure` row is written for each item returned in your search results | The item was offered to you but you may not have opened it |
+| **view** | A `view` row is written when you call `get_knowledge` on an item | You opened the full detail — a weak reuse signal |
+| **feedback** | A row is written in the `reuse_feedback` table when you call the `reuse_feedback` tool | You explicitly told the system whether the item helped — the strong reuse signal |
+
+Only `exposure`, `view`, and `feedback` are persisted as first-class rows in P0. `query` is derived from shared `request_id`s across exposure rows, so **0-hit searches are not counted in P0** — that's why the reports do not yet include a `hit_rate` metric.
 
 Reports prioritize `view` + `feedback` over `exposure` for the real reuse metrics (north star, top reused). Exposure is tracked for search-effectiveness analysis only.
 

--- a/docs/mcp-config-template.md
+++ b/docs/mcp-config-template.md
@@ -64,7 +64,7 @@ Once connected, your agent will have access to:
 | Tool | Purpose |
 |------|---------|
 | `publish_knowledge` | Share a finding with the team |
-| `query_knowledge` | Search knowledge by keywords (FTS5) — produces a `query` event; each returned item is logged as an `exposure` |
+| `query_knowledge` | Search knowledge by keywords (FTS5). Each returned item is logged as an `exposure` row (sharing a `request_id`); the query count is derived from distinct `request_id`s |
 | `semantic_search` | Search knowledge by meaning using vector similarity — finds conceptually related items even when exact words differ. Same event semantics as `query_knowledge` |
 | `list_knowledge` | Browse knowledge by project/tags |
 | `get_knowledge` | Read full detail of a knowledge item — produces a `view` event. Pass optional `query_context` to label why you opened it |

--- a/docs/mcp-config-template.md
+++ b/docs/mcp-config-template.md
@@ -64,11 +64,14 @@ Once connected, your agent will have access to:
 | Tool | Purpose |
 |------|---------|
 | `publish_knowledge` | Share a finding with the team |
-| `query_knowledge` | Search knowledge by keywords (FTS5) |
-| `semantic_search` | Search knowledge by meaning using vector similarity — finds conceptually related items even when exact words differ |
+| `query_knowledge` | Search knowledge by keywords (FTS5) — produces a `query` event; each returned item is logged as an `exposure` |
+| `semantic_search` | Search knowledge by meaning using vector similarity — finds conceptually related items even when exact words differ. Same event semantics as `query_knowledge` |
 | `list_knowledge` | Browse knowledge by project/tags |
-| `get_knowledge` | Read full detail of a knowledge item |
+| `get_knowledge` | Read full detail of a knowledge item — produces a `view` event. Pass optional `query_context` to label why you opened it |
+| `reuse_feedback` | After using an item, report `useful` / `not_useful` / `outdated`. This is the **strong reuse signal** that drives the team's north-star metric |
 | `update_knowledge` | Update metadata (tags, confidence, staleness, related_to) |
+
+> **Reuse tracking requires an authenticated API key.** Unauthenticated reads still work, but the backend cannot attribute `exposure` / `view` events to a specific agent, so those interactions won't appear in reuse reports. Always configure `TEAM_MEMORY_API_KEY` to be counted.
 
 ## Verification
 

--- a/docs/system-prompt-snippet.md
+++ b/docs/system-prompt-snippet.md
@@ -15,8 +15,18 @@ You have access to a shared team knowledge base via the Team Memory MCP tools. U
 
 1. Call `query_knowledge` with keywords related to your task and the project name.
 2. Call `semantic_search` with a natural language description of your task — this finds conceptually related knowledge even when exact keywords differ.
-3. If results are found, call `get_knowledge` to read the full detail.
+3. If results are found, call `get_knowledge` to read the full detail. Pass `query_context` describing what task prompted the view.
 4. Use existing knowledge as context. Do not redo analysis that has already been published.
+
+### After using a knowledge item
+
+Every `get_knowledge` call should be followed by a `reuse_feedback` call once you know whether the item helped:
+
+- `useful` — answered your question or saved you work.
+- `not_useful` — irrelevant to your task, or the claim was wrong.
+- `outdated` — used to be true but no longer applies (consider also publishing a superseding item).
+
+Skipping feedback means the team can't measure which knowledge is actually valuable. Treat `reuse_feedback` as mandatory, not optional.
 
 ### After completing a task
 
@@ -34,6 +44,7 @@ If you discovered something reusable (architectural insight, verified behavior, 
 - Do not publish ephemeral status, obvious facts, or conversation summaries.
 - Use `update_knowledge` only for metadata changes (tags, confidence, staleness_hint, related_to), never to change the claim itself.
 - When superseding, always publish a new item rather than editing the old one.
+- Always give `reuse_feedback` after `get_knowledge`. This is how the team measures which knowledge saves time.
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Document the four-event reuse model (`query` / `exposure` / `view` / `feedback`) at the top of `agent-protocol.md` so agents learn the terminology before the workflow.
- Make `reuse_feedback` a first-class step in the protocol: mandatory after every `get_knowledge`, with guidance on when to pick `useful` / `not_useful` / `outdated`.
- Update `get_knowledge` example and Example 1 workflow to pass `query_context` so `view` events carry a task label.
- Add `reuse_feedback` to the MCP tool table and flag that authenticated API keys are required for events to be attributed.
- Mirror the feedback step in `system-prompt-snippet.md` so integrators copy the updated protocol into their agents.

Closes #37 (documentation portion). Backend = PR #26 (merged). MCP tool = PR #27 (in review).

## Alignment with locked design
- Terminology: `query` / `exposure` / `view` / `feedback` — matches `usage_events.event_type` and the reuse report shape.
- Verdict enum: `useful` / `not_useful` / `outdated` — matches `reuse_feedback.verdict`.
- `knowledge_id` is UUID `TEXT` throughout.
- Call out that exposure is tracked but does not drive the north-star metric; view + feedback are the reuse signals.

## Test plan
- [ ] @Jet: doc-consistency review — UUID wording, four-term alignment, tool descriptions vs report metric definitions in PR #26.
- [ ] @Ein: spot-check that the `exposure` / `view` / `feedback` semantics in the prose match backend behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)