### PR TITLE
feat(dashboard): add Reuse report page (#39)

### DIFF
--- a/packages/dashboard/src/App.css
+++ b/packages/dashboard/src/App.css
@@ -477,6 +477,263 @@
 }
 
 /* Responsive */
+/* View tabs */
+.view-tabs {
+  display: flex;
+  gap: 4px;
+  margin-left: 16px;
+}
+
+.view-tab {
+  padding: 6px 14px;
+  border: none;
+  background: none;
+  color: var(--text-dim);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--sans);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.view-tab:hover {
+  background: var(--accent-bg);
+}
+
+.view-tab.active {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+/* Reuse view */
+.reuse-view {
+  flex: 1;
+  padding: 24px;
+  overflow-y: auto;
+  max-width: 1100px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.reuse-loading,
+.reuse-error {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-dim);
+}
+
+.reuse-error .title {
+  font-size: 16px;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+.reuse-cards {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.metric-card {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metric-card.highlight {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+
+.metric-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-dim);
+  font-weight: 600;
+}
+
+.metric-value {
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--text-h);
+  letter-spacing: -0.5px;
+}
+
+.metric-card.highlight .metric-value {
+  color: var(--accent);
+}
+
+.metric-hint {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+
+.reuse-section {
+  margin-bottom: 32px;
+}
+
+.reuse-section h2 {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-h);
+  margin-bottom: 6px;
+  letter-spacing: -0.1px;
+}
+
+.reuse-section-hint {
+  font-size: 13px;
+  color: var(--text-dim);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+
+.reuse-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 13px;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+}
+
+.reuse-table {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.reuse-table-head,
+.reuse-row {
+  display: grid;
+  grid-template-columns: 32px 1fr 64px 72px 220px;
+  gap: 12px;
+  padding: 10px 14px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.reuse-table-head {
+  background: var(--bg-secondary);
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border);
+}
+
+.reuse-row {
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.reuse-row:last-child {
+  border-bottom: none;
+}
+
+.reuse-row:hover {
+  background: var(--bg-secondary);
+}
+
+.reuse-col-rank {
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.reuse-col-claim {
+  color: var(--text-h);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reuse-col-num {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  color: var(--text);
+}
+
+.reuse-col-feedback {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
+.feedback-pill {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+.feedback-pill.useful {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.feedback-pill.not-useful {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.feedback-pill.outdated {
+  background: rgba(234, 179, 8, 0.15);
+  color: #a16207;
+}
+
+.reuse-never-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.reuse-never-row {
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.reuse-never-row:last-child {
+  border-bottom: none;
+}
+
+.reuse-never-row:hover {
+  background: var(--bg-secondary);
+}
+
+@media (max-width: 900px) {
+  .reuse-cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .reuse-table-head,
+  .reuse-row {
+    grid-template-columns: 28px 1fr 52px 60px;
+  }
+
+  .reuse-col-feedback {
+    display: none;
+  }
+}
+
 @media (max-width: 1200px) {
   .detail-panel {
     width: 380px;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import type { KnowledgeItem, KnowledgeListItem } from "./types";
+import type { KnowledgeItem, KnowledgeListItem, ReuseReport } from "./types";
 import {
   listKnowledge,
   searchKnowledge,
@@ -7,8 +7,11 @@ import {
   getAllFilters,
   getApiKey,
   setApiKey,
+  getReuseReport,
 } from "./api";
 import "./App.css";
+
+type View = "knowledge" | "reuse";
 
 function App() {
   const [items, setItems] = useState<KnowledgeListItem[]>([]);
@@ -25,6 +28,7 @@ function App() {
   const [searchMode, setSearchMode] = useState<"fts" | "semantic" | "hybrid" | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [apiKeyInput, setApiKeyInput] = useState(getApiKey() ?? "");
+  const [view, setView] = useState<View>("knowledge");
 
   useEffect(() => {
     getAllFilters().then(({ projects, owners, tags }) => {
@@ -82,9 +86,25 @@ function App() {
     <div className="app">
       <header className="app-header">
         <h1>Team Memory</h1>
-        <span className="stats">
-          {total} knowledge item{total !== 1 ? "s" : ""}
-        </span>
+        <nav className="view-tabs">
+          <button
+            className={`view-tab ${view === "knowledge" ? "active" : ""}`}
+            onClick={() => setView("knowledge")}
+          >
+            Knowledge
+          </button>
+          <button
+            className={`view-tab ${view === "reuse" ? "active" : ""}`}
+            onClick={() => setView("reuse")}
+          >
+            Reuse
+          </button>
+        </nav>
+        {view === "knowledge" && (
+          <span className="stats">
+            {total} knowledge item{total !== 1 ? "s" : ""}
+          </span>
+        )}
         <button
           className="settings-btn"
           onClick={() => setShowSettings(!showSettings)}
@@ -127,6 +147,9 @@ function App() {
         </div>
       )}
 
+      {view === "reuse" ? (
+        <ReuseView onNavigate={(id) => { setView("knowledge"); selectItem(id); }} />
+      ) : (
       <div className="app-body">
         <aside className="sidebar">
           <FilterSection
@@ -243,6 +266,7 @@ function App() {
           )}
         </div>
       </div>
+      )}
     </div>
   );
 }
@@ -430,6 +454,161 @@ function DetailView({
       )}
     </div>
   );
+}
+
+function ReuseView({ onNavigate }: { onNavigate: (id: string) => void }) {
+  const [report, setReport] = useState<ReuseReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getReuseReport()
+      .then(setReport)
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="reuse-view">
+        <div className="reuse-error">
+          <div className="title">Failed to load reuse report</div>
+          <div>{error}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!report) {
+    return (
+      <div className="reuse-view">
+        <div className="reuse-loading">Loading reuse report…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="reuse-view">
+      <section className="reuse-cards">
+        <MetricCard
+          label="Total queries"
+          value={report.total_queries.toString()}
+          hint="distinct searches that returned at least one result"
+        />
+        <MetricCard
+          label="Total views"
+          value={report.total_views.toString()}
+          hint="get_knowledge opens that record a view event"
+        />
+        <MetricCard
+          label="North star"
+          value={formatPct(report.north_star)}
+          hint="items viewed or marked useful by 2+ distinct owners"
+          highlight
+        />
+        <MetricCard
+          label="Never accessed"
+          value={formatPct(report.never_accessed_pct)}
+          hint={`${report.never_accessed.length} of ${report.total_items} items`}
+        />
+      </section>
+
+      <section className="reuse-section">
+        <h2>Top reused items</h2>
+        {report.top_reused.length === 0 ? (
+          <div className="reuse-empty">
+            No items have been viewed or received feedback yet.
+          </div>
+        ) : (
+          <div className="reuse-table">
+            <div className="reuse-table-head">
+              <span className="reuse-col-rank">#</span>
+              <span className="reuse-col-claim">Claim</span>
+              <span className="reuse-col-num">Views</span>
+              <span className="reuse-col-num">Owners</span>
+              <span className="reuse-col-feedback">Feedback</span>
+            </div>
+            {report.top_reused.map((item, idx) => (
+              <div
+                key={item.knowledge_id}
+                className="reuse-row"
+                onClick={() => onNavigate(item.knowledge_id)}
+              >
+                <span className="reuse-col-rank">{idx + 1}</span>
+                <span className="reuse-col-claim">{item.claim}</span>
+                <span className="reuse-col-num">{item.view_count}</span>
+                <span className="reuse-col-num">{item.unique_owners}</span>
+                <span className="reuse-col-feedback">
+                  {item.useful_feedback_count > 0 && (
+                    <span className="feedback-pill useful">
+                      {item.useful_feedback_count} useful
+                    </span>
+                  )}
+                  {item.not_useful_feedback_count > 0 && (
+                    <span className="feedback-pill not-useful">
+                      {item.not_useful_feedback_count} not useful
+                    </span>
+                  )}
+                  {item.outdated_feedback_count > 0 && (
+                    <span className="feedback-pill outdated">
+                      {item.outdated_feedback_count} outdated
+                    </span>
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="reuse-section">
+        <h2>Never accessed</h2>
+        <p className="reuse-section-hint">
+          Items with no exposure, view, or feedback. Candidates for better
+          tagging, consolidation, or retirement.
+        </p>
+        {report.never_accessed.length === 0 ? (
+          <div className="reuse-empty">
+            Every knowledge item has been touched at least once.
+          </div>
+        ) : (
+          <ul className="reuse-never-list">
+            {report.never_accessed.map((item) => (
+              <li
+                key={item.id}
+                className="reuse-never-row"
+                onClick={() => onNavigate(item.id)}
+              >
+                {item.claim}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  hint,
+  highlight,
+}: {
+  label: string;
+  value: string;
+  hint: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div className={`metric-card ${highlight ? "highlight" : ""}`}>
+      <div className="metric-label">{label}</div>
+      <div className="metric-value">{value}</div>
+      <div className="metric-hint">{hint}</div>
+    </div>
+  );
+}
+
+function formatPct(value: number): string {
+  return `${Math.round(value * 100)}%`;
 }
 
 function formatDate(iso: string): string {

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -1,4 +1,4 @@
-import type { KnowledgeItem, KnowledgeListItem } from "./types";
+import type { KnowledgeItem, KnowledgeListItem, ReuseReport } from "./types";
 import { mockKnowledge } from "./mockData";
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:3456/api";
@@ -187,6 +187,12 @@ export async function searchKnowledge(params: SearchParams): Promise<PaginatedRe
 export async function getKnowledge(id: string): Promise<KnowledgeItem | null> {
   if (USE_MOCK) return mockGet(id);
   return fetchGet(id);
+}
+
+export async function getReuseReport(): Promise<ReuseReport> {
+  const res = await fetch(`${API_BASE}/reports/reuse`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
 }
 
 // --- Helpers ---

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -39,3 +39,28 @@ export interface KnowledgeListItem {
   search_mode?: "fts" | "semantic" | "hybrid";
   created_at: string;
 }
+
+export interface TopReusedItem {
+  knowledge_id: string;
+  claim: string;
+  view_count: number;
+  unique_owners: number;
+  useful_feedback_count: number;
+  not_useful_feedback_count: number;
+  outdated_feedback_count: number;
+}
+
+export interface NeverAccessedItem {
+  id: string;
+  claim: string;
+}
+
+export interface ReuseReport {
+  total_queries: number;
+  total_views: number;
+  total_items: number;
+  never_accessed_pct: number;
+  north_star: number;
+  top_reused: TopReusedItem[];
+  never_accessed: NeverAccessedItem[];
+}


### PR DESCRIPTION
## Summary
- Adds a top-level **Reuse** tab to the dashboard next to **Knowledge**
- Renders the P0 reuse report from `GET /api/reports/reuse` (backend from #26):
  - Four metric cards: `total_queries`, `total_views`, `north_star`, `never_accessed_pct`
  - Top reused table (top 10), ranked by `view_count + useful_feedback_count`, with per-item feedback pills (useful / not_useful / outdated)
  - Never-accessed list (items with zero exposure, view, and feedback)
- Clicking a top-reused row or never-accessed row routes back to the Knowledge view with that item selected
- Closes #39

## Notes on terminology
Terms follow the locked four-signal vocabulary: **query / exposure / view / feedback**. `query` is framed as "distinct searches that returned ≥1 result" (派生量, not a first-class event). `hit_rate` is deliberately omitted — 0-hit search is not observable in P0.

## Smoke test status
- `npm run build --workspace=packages/dashboard` passes (tsc + vite build clean)
- Live smoke test against shared backend at :3460 returned **404** on `/api/reports/reuse`. The process listening on 3460 is running from another agent's checkout (pre-#26). The endpoint exists in `main` (`routes.ts:435`), so once the shared backend is restarted from a fresh checkout, the dashboard should light up. Happy to re-run smoke test after that.

## Test plan
- [ ] Start backend from current `main` (must include #26)
- [ ] `npm run dev --workspace=packages/dashboard`
- [ ] Click **Reuse** tab → 4 metric cards render, north star card is highlighted
- [ ] Seed data via MCP (`publish_knowledge` + `query_context` reads) then reload → top_reused and never_accessed populate
- [ ] Click a top-reused row → switches to Knowledge tab with the item selected
- [ ] Click a never-accessed row → switches to Knowledge tab with the item selected
- [ ] Resize below 900px → cards stack, table stays readable

## Reviewers
- @Ein for contract alignment with `/api/reports/reuse` response shape
- @Jet for terminology consistency with Spike's #28 docs and the #27 MCP surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)