### PR TITLE
feat(dashboard): Reuse page P0.1 — #44

### DIFF
--- a/packages/dashboard/src/App.css
+++ b/packages/dashboard/src/App.css
@@ -529,9 +529,92 @@
   margin-bottom: 6px;
 }
 
+.reuse-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.reuse-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reuse-toolbar-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-dim);
+  font-weight: 600;
+}
+
+.reuse-toolbar-spacer {
+  flex: 1;
+}
+
+.reuse-toolbar-status {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.reuse-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.reuse-toggle-btn {
+  background: transparent;
+  border: none;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: pointer;
+  border-right: 1px solid var(--border);
+  transition: background 0.15s, color 0.15s;
+}
+
+.reuse-toggle-btn:last-child {
+  border-right: none;
+}
+
+.reuse-toggle-btn:hover {
+  color: var(--text);
+}
+
+.reuse-toggle-btn.active {
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.reuse-select,
+.reuse-input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-family: inherit;
+}
+
+.reuse-input {
+  width: 80px;
+}
+
 .reuse-cards {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 12px;
   margin-bottom: 32px;
 }
@@ -719,6 +802,46 @@
   background: var(--bg-secondary);
 }
 
+.reuse-zero-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.reuse-zero-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--border);
+}
+
+.reuse-zero-row:last-child {
+  border-bottom: none;
+}
+
+.reuse-zero-example {
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.reuse-zero-count {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--bg-secondary);
+}
+
+@media (max-width: 1280px) {
+  .reuse-cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 900px) {
   .reuse-cards {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -731,6 +854,10 @@
 
   .reuse-col-feedback {
     display: none;
+  }
+
+  .reuse-toolbar {
+    gap: 10px;
   }
 }
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -590,7 +590,7 @@ function ReuseView({
             <MetricCard
               label="Never accessed"
               value={formatPct(report.never_accessed_pct)}
-              hint={`${report.never_accessed.length} of ${report.total_items} items — no exposure, view, or feedback`}
+              hint={`${Math.round(report.never_accessed_pct * report.total_items)} of ${report.total_items} items have no exposure, view, or feedback (baseline, ignores min age filter)`}
             />
           </section>
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -590,7 +590,7 @@ function ReuseView({
             <MetricCard
               label="Never accessed"
               value={formatPct(report.never_accessed_pct)}
-              hint={`${Math.round(report.never_accessed_pct * report.total_items)} of ${report.total_items} items have no exposure, view, or feedback (baseline, ignores min age filter)`}
+              hint={`${Math.round(report.never_accessed_pct * report.total_items)} of ${report.total_items} items have no exposure, view, or feedback — 基线计数，不随 min-age 过滤变化`}
             />
           </section>
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import type { KnowledgeItem, KnowledgeListItem, ReuseReport } from "./types";
+import type { KnowledgeItem, KnowledgeListItem, ReuseReport, ReuseSince } from "./types";
 import {
   listKnowledge,
   searchKnowledge,
@@ -148,7 +148,10 @@ function App() {
       )}
 
       {view === "reuse" ? (
-        <ReuseView onNavigate={(id) => { setView("knowledge"); selectItem(id); }} />
+        <ReuseView
+          projects={projects}
+          onNavigate={(id) => { setView("knowledge"); selectItem(id); }}
+        />
       ) : (
       <div className="app-body">
         <aside className="sidebar">
@@ -456,133 +459,243 @@ function DetailView({
   );
 }
 
-function ReuseView({ onNavigate }: { onNavigate: (id: string) => void }) {
+function ReuseView({
+  projects,
+  onNavigate,
+}: {
+  projects: string[];
+  onNavigate: (id: string) => void;
+}) {
   const [report, setReport] = useState<ReuseReport | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [since, setSince] = useState<ReuseSince>("7d");
+  const [projectFilter, setProjectFilter] = useState<string>("");
+  const [minAgeInput, setMinAgeInput] = useState<string>("");
 
   useEffect(() => {
-    getReuseReport()
-      .then(setReport)
-      .catch((e) => setError(String(e)));
-  }, []);
+    setLoading(true);
+    setError(null);
+    const minAge = minAgeInput.trim() === "" ? undefined : Number(minAgeInput);
+    const params = {
+      since,
+      project: projectFilter || undefined,
+      min_age_days: minAge !== undefined && !Number.isNaN(minAge) ? minAge : undefined,
+    };
+    getReuseReport(params)
+      .then((r) => {
+        setReport(r);
+        setLoading(false);
+      })
+      .catch((e) => {
+        setError(String(e));
+        setLoading(false);
+      });
+  }, [since, projectFilter, minAgeInput]);
 
-  if (error) {
-    return (
-      <div className="reuse-view">
+  const sinceLabel =
+    since === "7d" ? "最近 7 天" : since === "30d" ? "最近 30 天" : "全量";
+
+  return (
+    <div className="reuse-view">
+      <section className="reuse-toolbar">
+        <div className="reuse-toolbar-group">
+          <span className="reuse-toolbar-label">时间窗</span>
+          <div className="reuse-toggle">
+            {(["7d", "30d", "all"] as ReuseSince[]).map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                className={`reuse-toggle-btn ${since === opt ? "active" : ""}`}
+                onClick={() => setSince(opt)}
+              >
+                {opt === "7d" ? "最近 7 天" : opt === "30d" ? "最近 30 天" : "全量"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="reuse-toolbar-group">
+          <span className="reuse-toolbar-label">项目</span>
+          <select
+            className="reuse-select"
+            value={projectFilter}
+            onChange={(e) => setProjectFilter(e.target.value)}
+          >
+            <option value="">全部项目</option>
+            {projects.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="reuse-toolbar-group">
+          <span
+            className="reuse-toolbar-label"
+            title="Only filters the 'Never accessed' list — items younger than N days are excluded"
+          >
+            min age (days)
+          </span>
+          <input
+            type="number"
+            min={0}
+            className="reuse-input"
+            placeholder="0"
+            value={minAgeInput}
+            onChange={(e) => setMinAgeInput(e.target.value)}
+          />
+        </div>
+        <div className="reuse-toolbar-spacer" />
+        <span className="reuse-toolbar-status">
+          {loading ? "Loading…" : `Window: ${sinceLabel}`}
+        </span>
+      </section>
+
+      {error ? (
         <div className="reuse-error">
           <div className="title">Failed to load reuse report</div>
           <div>{error}</div>
         </div>
-      </div>
-    );
-  }
-
-  if (!report) {
-    return (
-      <div className="reuse-view">
+      ) : !report ? (
         <div className="reuse-loading">Loading reuse report…</div>
-      </div>
-    );
-  }
+      ) : (
+        <>
+          <section className="reuse-cards">
+            <MetricCard
+              label="Total queries"
+              value={report.total_queries.toString()}
+              hint="raw query events in window"
+            />
+            <MetricCard
+              label="Hit rate"
+              value={formatPct(report.hit_rate)}
+              hint="queries with ≥1 result / total queries"
+            />
+            <MetricCard
+              label="Total views"
+              value={report.total_views.toString()}
+              hint="raw view events (get_knowledge opens)"
+            />
+            <MetricCard
+              label="Feedback coverage"
+              value={formatPct(report.feedback_coverage)}
+              hint="per (owner, item) pair — of viewed pairs, how many have feedback"
+            />
+            <MetricCard
+              label="North star"
+              value={formatPct(report.north_star_pct)}
+              hint={`${report.north_star_count} items viewed or marked useful by 2+ distinct owners`}
+              highlight
+            />
+            <MetricCard
+              label="Never accessed"
+              value={formatPct(report.never_accessed_pct)}
+              hint={`${report.never_accessed.length} of ${report.total_items} items — no exposure, view, or feedback`}
+            />
+          </section>
 
-  return (
-    <div className="reuse-view">
-      <section className="reuse-cards">
-        <MetricCard
-          label="Total queries"
-          value={report.total_queries.toString()}
-          hint="distinct searches that returned at least one result"
-        />
-        <MetricCard
-          label="Total views"
-          value={report.total_views.toString()}
-          hint="get_knowledge opens that record a view event"
-        />
-        <MetricCard
-          label="North star"
-          value={formatPct(report.north_star)}
-          hint="items viewed or marked useful by 2+ distinct owners"
-          highlight
-        />
-        <MetricCard
-          label="Never accessed"
-          value={formatPct(report.never_accessed_pct)}
-          hint={`${report.never_accessed.length} of ${report.total_items} items`}
-        />
-      </section>
-
-      <section className="reuse-section">
-        <h2>Top reused items</h2>
-        {report.top_reused.length === 0 ? (
-          <div className="reuse-empty">
-            No items have been viewed or received feedback yet.
-          </div>
-        ) : (
-          <div className="reuse-table">
-            <div className="reuse-table-head">
-              <span className="reuse-col-rank">#</span>
-              <span className="reuse-col-claim">Claim</span>
-              <span className="reuse-col-num">Views</span>
-              <span className="reuse-col-num">Owners</span>
-              <span className="reuse-col-feedback">Feedback</span>
-            </div>
-            {report.top_reused.map((item, idx) => (
-              <div
-                key={item.knowledge_id}
-                className="reuse-row"
-                onClick={() => onNavigate(item.knowledge_id)}
-              >
-                <span className="reuse-col-rank">{idx + 1}</span>
-                <span className="reuse-col-claim">{item.claim}</span>
-                <span className="reuse-col-num">{item.view_count}</span>
-                <span className="reuse-col-num">{item.unique_owners}</span>
-                <span className="reuse-col-feedback">
-                  {item.useful_feedback_count > 0 && (
-                    <span className="feedback-pill useful">
-                      {item.useful_feedback_count} useful
-                    </span>
-                  )}
-                  {item.not_useful_feedback_count > 0 && (
-                    <span className="feedback-pill not-useful">
-                      {item.not_useful_feedback_count} not useful
-                    </span>
-                  )}
-                  {item.outdated_feedback_count > 0 && (
-                    <span className="feedback-pill outdated">
-                      {item.outdated_feedback_count} outdated
-                    </span>
-                  )}
-                </span>
+          <section className="reuse-section">
+            <h2>Top reused items</h2>
+            {report.top_reused.length === 0 ? (
+              <div className="reuse-empty">
+                No items have been viewed or received feedback yet.
               </div>
-            ))}
-          </div>
-        )}
-      </section>
+            ) : (
+              <div className="reuse-table">
+                <div className="reuse-table-head">
+                  <span className="reuse-col-rank">#</span>
+                  <span className="reuse-col-claim">Claim</span>
+                  <span className="reuse-col-num">Views</span>
+                  <span className="reuse-col-num">Owners</span>
+                  <span className="reuse-col-feedback">Feedback</span>
+                </div>
+                {report.top_reused.map((item, idx) => (
+                  <div
+                    key={item.knowledge_id}
+                    className="reuse-row"
+                    onClick={() => onNavigate(item.knowledge_id)}
+                  >
+                    <span className="reuse-col-rank">{idx + 1}</span>
+                    <span className="reuse-col-claim">{item.claim}</span>
+                    <span className="reuse-col-num">{item.view_count}</span>
+                    <span className="reuse-col-num">{item.unique_owners}</span>
+                    <span className="reuse-col-feedback">
+                      {item.useful_feedback_count > 0 && (
+                        <span className="feedback-pill useful">
+                          {item.useful_feedback_count} useful
+                        </span>
+                      )}
+                      {item.not_useful_feedback_count > 0 && (
+                        <span className="feedback-pill not-useful">
+                          {item.not_useful_feedback_count} not useful
+                        </span>
+                      )}
+                      {item.outdated_feedback_count > 0 && (
+                        <span className="feedback-pill outdated">
+                          {item.outdated_feedback_count} outdated
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
 
-      <section className="reuse-section">
-        <h2>Never accessed</h2>
-        <p className="reuse-section-hint">
-          Items with no exposure, view, or feedback. Candidates for better
-          tagging, consolidation, or retirement.
-        </p>
-        {report.never_accessed.length === 0 ? (
-          <div className="reuse-empty">
-            Every knowledge item has been touched at least once.
-          </div>
-        ) : (
-          <ul className="reuse-never-list">
-            {report.never_accessed.map((item) => (
-              <li
-                key={item.id}
-                className="reuse-never-row"
-                onClick={() => onNavigate(item.id)}
-              >
-                {item.claim}
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+          <section className="reuse-section">
+            <h2>Top 0-hit keywords</h2>
+            <p className="reuse-section-hint">
+              Queries that returned no results — deduped by normalized key
+              (trim + lowercase + collapse whitespace). Candidates for new
+              knowledge or better tagging.
+            </p>
+            {report.top_0hit_keywords.length === 0 ? (
+              <div className="reuse-empty">
+                No 0-hit queries in this window.
+              </div>
+            ) : (
+              <div className="reuse-zero-list">
+                {report.top_0hit_keywords.map((kw) => (
+                  <div key={kw.normalized_key} className="reuse-zero-row">
+                    <span className="reuse-zero-example">{kw.example_text}</span>
+                    <span className="reuse-zero-count">
+                      {kw.query_count}×
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="reuse-section">
+            <h2>Never accessed</h2>
+            <p className="reuse-section-hint">
+              Items with no exposure, view, or feedback. Candidates for better
+              tagging, consolidation, or retirement.
+              {minAgeInput.trim() !== "" && !Number.isNaN(Number(minAgeInput)) && (
+                <> Filtered to items older than {minAgeInput} day(s).</>
+              )}
+            </p>
+            {report.never_accessed.length === 0 ? (
+              <div className="reuse-empty">
+                Every knowledge item has been touched at least once.
+              </div>
+            ) : (
+              <ul className="reuse-never-list">
+                {report.never_accessed.map((item) => (
+                  <li
+                    key={item.id}
+                    className="reuse-never-row"
+                    onClick={() => onNavigate(item.id)}
+                  >
+                    {item.claim}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -8,7 +8,7 @@ import { mockKnowledge, mockReuseReport } from "./mockData";
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:3456/api";
 const USE_MOCK = false;
-const USE_REUSE_MOCK = true;
+const USE_REUSE_MOCK = false;
 
 let _apiKey: string | null = localStorage.getItem("tm_api_key");
 

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -1,8 +1,14 @@
-import type { KnowledgeItem, KnowledgeListItem, ReuseReport } from "./types";
-import { mockKnowledge } from "./mockData";
+import type {
+  KnowledgeItem,
+  KnowledgeListItem,
+  ReuseReport,
+  ReuseReportParams,
+} from "./types";
+import { mockKnowledge, mockReuseReport } from "./mockData";
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:3456/api";
 const USE_MOCK = false;
+const USE_REUSE_MOCK = true;
 
 let _apiKey: string | null = localStorage.getItem("tm_api_key");
 
@@ -189,8 +195,15 @@ export async function getKnowledge(id: string): Promise<KnowledgeItem | null> {
   return fetchGet(id);
 }
 
-export async function getReuseReport(): Promise<ReuseReport> {
-  const res = await fetch(`${API_BASE}/reports/reuse`, { headers: authHeaders() });
+export async function getReuseReport(params: ReuseReportParams = {}): Promise<ReuseReport> {
+  if (USE_REUSE_MOCK) return mockReuseReport;
+  const url = new URL(`${API_BASE}/reports/reuse`);
+  if (params.since && params.since !== "all") url.searchParams.set("since", params.since);
+  if (params.project) url.searchParams.set("project", params.project);
+  if (params.min_age_days !== undefined) {
+    url.searchParams.set("min_age_days", String(params.min_age_days));
+  }
+  const res = await fetch(url, { headers: authHeaders() });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }

--- a/packages/dashboard/src/mockData.ts
+++ b/packages/dashboard/src/mockData.ts
@@ -1,4 +1,4 @@
-import type { KnowledgeItem } from "./types";
+import type { KnowledgeItem, ReuseReport } from "./types";
 
 export const mockKnowledge: KnowledgeItem[] = [
   {
@@ -119,3 +119,56 @@ Agent 工作目录在 ~/.slock/agents/{agentId}/。`,
     created_at: "2026-04-14T00:10:00Z",
   },
 ];
+
+export const mockReuseReport: ReuseReport = {
+  total_queries: 12,
+  hit_rate: 0.75,
+  total_views: 9,
+  total_items: 42,
+  never_accessed_pct: 0.31,
+  feedback_coverage: 0.67,
+  north_star_count: 6,
+  north_star_pct: 0.14,
+  top_reused: [
+    {
+      knowledge_id: "6579131c-17c0-47fa-8b2e-a29380d0b5de",
+      claim: "Shared Team Memory deployments should set TEAM_MEMORY_DB to an absolute path",
+      view_count: 3,
+      unique_owners: 2,
+      useful_feedback_count: 2,
+      not_useful_feedback_count: 0,
+      outdated_feedback_count: 0,
+    },
+    {
+      knowledge_id: "k-001",
+      claim: "infer-monorepo 的主架构轴是 DEPLOY_MODE，不是目录结构",
+      view_count: 2,
+      unique_owners: 2,
+      useful_feedback_count: 1,
+      not_useful_feedback_count: 0,
+      outdated_feedback_count: 0,
+    },
+  ],
+  top_0hit_keywords: [
+    {
+      normalized_key: "billing refund",
+      example_text: "Billing refund",
+      query_count: 5,
+    },
+    {
+      normalized_key: "stripe webhook retry",
+      example_text: "stripe webhook retry",
+      query_count: 3,
+    },
+  ],
+  never_accessed: [
+    {
+      id: "60ad7408-ee84-4eb0-98f3-1dc1e5290546",
+      claim: "In multi-Node environments, Team Memory backend and MCP should pin the same Node major version",
+    },
+    {
+      id: "k-007",
+      claim: "@slock-ai/daemon 没有做混淆，代码完全可读",
+    },
+  ],
+};

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -55,12 +55,30 @@ export interface NeverAccessedItem {
   claim: string;
 }
 
+export interface ZeroHitKeyword {
+  normalized_key: string;
+  example_text: string;
+  query_count: number;
+}
+
 export interface ReuseReport {
   total_queries: number;
+  hit_rate: number;
   total_views: number;
   total_items: number;
   never_accessed_pct: number;
-  north_star: number;
+  feedback_coverage: number;
+  north_star_count: number;
+  north_star_pct: number;
   top_reused: TopReusedItem[];
+  top_0hit_keywords: ZeroHitKeyword[];
   never_accessed: NeverAccessedItem[];
+}
+
+export type ReuseSince = "7d" | "30d" | "all";
+
+export interface ReuseReportParams {
+  since?: ReuseSince;
+  project?: string;
+  min_age_days?: number;
 }


### PR DESCRIPTION
## Summary

Dashboard Reuse page for task **#44 (M3-dashboard)**, aligned to the v3.1 final response contract (Faye msg `e884be6e`). Live against the real `/api/reports/reuse` now that **#41 M1b** is merged.

### Shipped

- **Top toolbar**: time-window toggle `最近 7 天 / 最近 30 天 / 全量` (copy locked), project dropdown, `min_age_days` input
- **6 metric cards** (up from 4): Total queries, Hit rate, Total views, Feedback coverage, North star, Never accessed
  - `total_views` hint: "raw view events (get_knowledge opens)"
  - `feedback_coverage` hint: "per (owner, item) pair — of viewed pairs, how many have feedback"
  - `north_star`: shows `north_star_pct` as %, `north_star_count` in the hint
  - `never_accessed` hint: count derived from the **unfiltered baseline** (`pct × total_items`) and tagged "ignores min age filter", so the percentage and the displayed count stay consistent when `min_age_days` is applied
- **Top 0-hit keywords** section: deduped by `normalized_key`, displays `example_text` + query count
- **Query-string construction** in `getReuseReport`: `?since=7d/30d/(omit)`, `?project=`, `?min_age_days=`
- `ReuseSince` / `ReuseReportParams` types exported from `types.ts`
- `USE_REUSE_MOCK = false` — `mockReuseReport` retained as fallback only

### Smoke test (against shared backend `localhost:3460`, M1b @ `f929b30`)

- `GET /api/reports/reuse` → 200 with all v3.1 fields (`feedback_coverage`, `north_star_pct`, `north_star_count`, `top_0hit_keywords`, `never_accessed_pct`)
- `?min_age_days=999` → `never_accessed.length=0` while `never_accessed_pct=0.25` stays — exactly matches the v3.1 lock (list filtered, pct on baseline)

### Not in scope

- `exposed_not_viewed` field (P1, not P0.1)

## Test plan

- [x] `tsc -b && vite build` passes
- [x] Real-API smoke against shared backend (above)
- [x] `min_age_days` round-trip: list shrinks, pct stays — verified in JSON, rendered consistently in UI
- [ ] Reviewer (Ein — contract): request-shape ↔ M1b handler (`?since=7d/30d/omit`, `?project=`, `?min_age_days=`)
- [ ] Reviewer (Jet — wording): "最近 7 天" copy lock, tooltip units, never_accessed semantic text, baseline-vs-filter hint phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)