### PR TITLE
P0.1 M1a: make query a first-class usage event

### DIFF
--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -6,8 +6,18 @@ const DB_PATH = process.env.TEAM_MEMORY_DB ?? path.join(process.cwd(), "team-mem
 
 let _db: Database.Database | null = null;
 
+interface TableColumnInfo {
+  name: string;
+  notnull: number;
+}
+
+function tableInfo(db: Database.Database, table: string): TableColumnInfo[] {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as TableColumnInfo[];
+  return rows;
+}
+
 function hasColumn(db: Database.Database, table: string, column: string): boolean {
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  const rows = tableInfo(db, table);
   return rows.some((row) => row.name === column);
 }
 
@@ -15,6 +25,105 @@ function ensureColumn(db: Database.Database, table: string, column: string, defi
   if (!hasColumn(db, table, column)) {
     db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
   }
+}
+
+function tableSql(db: Database.Database, table: string): string | null {
+  const row = db.prepare(
+    "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(table) as { sql: string | null } | undefined;
+  return row?.sql ?? null;
+}
+
+function createUsageEventsTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS usage_events (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      knowledge_id  TEXT REFERENCES knowledge(id) ON DELETE CASCADE,
+      owner         TEXT NOT NULL,
+      event_type    TEXT NOT NULL CHECK (event_type IN ('query', 'exposure', 'view')),
+      request_id    TEXT,
+      query_text    TEXT,
+      result_count  INTEGER,
+      project       TEXT NOT NULL DEFAULT '',
+      search_mode   TEXT CHECK (search_mode IN ('fts', 'semantic', 'hybrid')),
+      query_context TEXT,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+function createUsageEventsIndexes(db: Database.Database): void {
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_usage_events_knowledge ON usage_events(knowledge_id);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_owner ON usage_events(owner);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_request ON usage_events(request_id);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_created ON usage_events(created_at);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_project ON usage_events(project);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_event_type ON usage_events(event_type);
+  `);
+}
+
+function ensureUsageEventsSchema(db: Database.Database): void {
+  createUsageEventsTable(db);
+
+  const columns = tableInfo(db, "usage_events");
+  if (columns.length === 0) {
+    createUsageEventsIndexes(db);
+    return;
+  }
+
+  const sql = tableSql(db, "usage_events")?.toLowerCase() ?? "";
+  const knowledgeId = columns.find((column) => column.name === "knowledge_id");
+  const project = columns.find((column) => column.name === "project");
+  const needsMigration =
+    !hasColumn(db, "usage_events", "query_text")
+    || !hasColumn(db, "usage_events", "result_count")
+    || !hasColumn(db, "usage_events", "project")
+    || !hasColumn(db, "usage_events", "search_mode")
+    || !sql.includes("'query'")
+    || knowledgeId?.notnull === 1
+    || project?.notnull !== 1;
+
+  if (!needsMigration) {
+    createUsageEventsIndexes(db);
+    return;
+  }
+
+  db.exec(`
+    ALTER TABLE usage_events RENAME TO usage_events_legacy;
+    DROP INDEX IF EXISTS idx_usage_events_knowledge;
+    DROP INDEX IF EXISTS idx_usage_events_owner;
+    DROP INDEX IF EXISTS idx_usage_events_request;
+    DROP INDEX IF EXISTS idx_usage_events_created;
+    DROP INDEX IF EXISTS idx_usage_events_project;
+    DROP INDEX IF EXISTS idx_usage_events_event_type;
+  `);
+
+  createUsageEventsTable(db);
+
+  db.exec(`
+    INSERT INTO usage_events (
+      id, knowledge_id, owner, event_type, request_id,
+      query_text, result_count, project, search_mode, query_context, created_at
+    )
+    SELECT
+      legacy.id,
+      legacy.knowledge_id,
+      legacy.owner,
+      legacy.event_type,
+      legacy.request_id,
+      NULL,
+      NULL,
+      COALESCE(knowledge.project, ''),
+      NULL,
+      legacy.query_context,
+      legacy.created_at
+    FROM usage_events_legacy AS legacy
+    LEFT JOIN knowledge ON knowledge.id = legacy.knowledge_id
+  `);
+
+  db.exec("DROP TABLE usage_events_legacy");
+  createUsageEventsIndexes(db);
 }
 
 export function getDb(): Database.Database {
@@ -80,21 +189,6 @@ export function getDb(): Database.Database {
     CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(owner);
     CREATE INDEX IF NOT EXISTS idx_api_keys_revoked_at ON api_keys(revoked_at);
 
-    CREATE TABLE IF NOT EXISTS usage_events (
-      id            INTEGER PRIMARY KEY AUTOINCREMENT,
-      knowledge_id  TEXT NOT NULL REFERENCES knowledge(id) ON DELETE CASCADE,
-      owner         TEXT NOT NULL,
-      event_type    TEXT NOT NULL CHECK (event_type IN ('exposure', 'view')),
-      request_id    TEXT,
-      query_context TEXT,
-      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_usage_events_knowledge ON usage_events(knowledge_id);
-    CREATE INDEX IF NOT EXISTS idx_usage_events_owner ON usage_events(owner);
-    CREATE INDEX IF NOT EXISTS idx_usage_events_request ON usage_events(request_id);
-    CREATE INDEX IF NOT EXISTS idx_usage_events_created ON usage_events(created_at);
-
     CREATE TABLE IF NOT EXISTS reuse_feedback (
       id            INTEGER PRIMARY KEY AUTOINCREMENT,
       knowledge_id  TEXT NOT NULL REFERENCES knowledge(id) ON DELETE CASCADE,
@@ -109,6 +203,7 @@ export function getDb(): Database.Database {
     CREATE INDEX IF NOT EXISTS idx_reuse_feedback_created ON reuse_feedback(created_at);
   `);
 
+  ensureUsageEventsSchema(_db);
   ensureColumn(_db, "knowledge", "duplicate_of", "TEXT");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_knowledge_duplicate_of ON knowledge(duplicate_of)");
   ensureColumn(_db, "knowledge", "embedding", "BLOB");

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -395,6 +395,14 @@ api.get("/knowledge/semantic-search", async (c) => {
 
   const [queryEmbedding] = await embedTexts([q]);
   if (!queryEmbedding) {
+    if (maybeAuth) {
+      recordSearchEvents(db, maybeAuth.owner, {
+        items: [],
+        project: project ?? null,
+        queryText: q,
+        searchMode: "semantic",
+      });
+    }
     return c.json({ items: [], total: 0 });
   }
 

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -24,6 +24,11 @@ interface SemanticKnowledgeRow extends KnowledgeRow {
 type SearchMode = "fts" | "semantic" | "hybrid";
 type ReuseVerdict = "useful" | "not_useful" | "outdated";
 
+interface TrackedSearchItem {
+  id: string;
+  project: string;
+}
+
 // Prefer semantic signal, but give a small bonus when a row matches both worlds.
 const HYBRID_FTS_WEIGHT = 0.35;
 const HYBRID_SEMANTIC_WEIGHT = 0.65;
@@ -163,39 +168,68 @@ async function runSemanticCandidates(
 const VALID_CONFIDENCE = new Set(["high", "medium", "low"]);
 const VALID_REUSE_VERDICTS = new Set<ReuseVerdict>(["useful", "not_useful", "outdated"]);
 
-function recordExposureEvents(
+function recordSearchEvents(
   db: ReturnType<typeof getDb>,
   owner: string,
-  knowledgeIds: string[],
-  queryContext: string,
+  input: {
+    items: TrackedSearchItem[];
+    project: string | null;
+    queryText: string;
+    searchMode: SearchMode;
+  },
 ): void {
-  if (knowledgeIds.length === 0) return;
-
   const requestId = uuidv4();
-  const insert = db.prepare(
-    `INSERT INTO usage_events (knowledge_id, owner, event_type, request_id, query_context)
-     VALUES (?, ?, 'exposure', ?, ?)`,
+  const insertQuery = db.prepare(
+    `INSERT INTO usage_events (
+      knowledge_id, owner, event_type, request_id, query_text,
+      result_count, project, search_mode, query_context
+    ) VALUES (NULL, ?, 'query', ?, ?, ?, ?, ?, NULL)`,
+  );
+  const insertExposure = db.prepare(
+    `INSERT INTO usage_events (
+      knowledge_id, owner, event_type, request_id, query_text,
+      result_count, project, search_mode, query_context
+    ) VALUES (?, ?, 'exposure', ?, NULL, NULL, ?, ?, ?)`,
   );
 
-  const transaction = db.transaction((ids: string[]) => {
-    for (const knowledgeId of ids) {
-      insert.run(knowledgeId, owner, requestId, queryContext);
+  const transaction = db.transaction((items: TrackedSearchItem[]) => {
+    insertQuery.run(
+      owner,
+      requestId,
+      input.queryText,
+      items.length,
+      input.project ?? "",
+      input.searchMode,
+    );
+
+    for (const item of items) {
+      insertExposure.run(
+        item.id,
+        owner,
+        requestId,
+        item.project,
+        input.searchMode,
+        input.queryText,
+      );
     }
   });
 
-  transaction(knowledgeIds);
+  transaction(input.items);
 }
 
 function recordViewEvent(
   db: ReturnType<typeof getDb>,
   owner: string,
   knowledgeId: string,
+  project: string,
   queryContext: string | null,
 ): void {
   db.prepare(
-    `INSERT INTO usage_events (knowledge_id, owner, event_type, request_id, query_context)
-     VALUES (?, ?, 'view', NULL, ?)`,
-  ).run(knowledgeId, owner, queryContext);
+    `INSERT INTO usage_events (
+      knowledge_id, owner, event_type, request_id, query_text,
+      result_count, project, search_mode, query_context
+    ) VALUES (?, ?, 'view', NULL, NULL, NULL, ?, NULL, ?)`,
+  ).run(knowledgeId, owner, project, queryContext);
 }
 
 // 1. POST /api/knowledge
@@ -337,7 +371,12 @@ api.get("/knowledge/search", async (c) => {
     .map(({ hybrid_score: _hybridScore, fts_score: _ftsScore, semantic_score: _semanticScore, ...item }) => item);
 
   if (maybeAuth) {
-    recordExposureEvents(db, maybeAuth.owner, items.map((item) => item.id), q);
+    recordSearchEvents(db, maybeAuth.owner, {
+      items: items.map((item) => ({ id: item.id, project: item.project })),
+      project: project ?? null,
+      queryText: q,
+      searchMode: "hybrid",
+    });
   }
 
   return c.json({ items, total: merged.size });
@@ -385,7 +424,12 @@ api.get("/knowledge/semantic-search", async (c) => {
 
   const items = ranked.slice(0, limit);
   if (maybeAuth) {
-    recordExposureEvents(db, maybeAuth.owner, items.map((item) => item.id), q);
+    recordSearchEvents(db, maybeAuth.owner, {
+      items: items.map((item) => ({ id: item.id, project: item.project })),
+      project: project ?? null,
+      queryText: q,
+      searchMode: "semantic",
+    });
   }
 
   return c.json({ items, total: ranked.length });
@@ -426,7 +470,7 @@ api.get("/knowledge/:id", (c) => {
   const maybeAuth = getOptionalApiAuth(c);
   if (maybeAuth instanceof Response) return maybeAuth;
   if (maybeAuth) {
-    recordViewEvent(db, maybeAuth.owner, row.id, c.req.query("query_context") ?? null);
+    recordViewEvent(db, maybeAuth.owner, row.id, row.project, c.req.query("query_context") ?? null);
   }
   return c.json(rowToJson(row));
 });
@@ -438,12 +482,14 @@ api.get("/reports/reuse", (c) => {
     "SELECT id, claim, created_at FROM knowledge ORDER BY created_at ASC",
   ).all() as Array<{ id: string; claim: string; created_at: string }>;
   const usageRows = db.prepare(
-    "SELECT knowledge_id, owner, event_type, request_id FROM usage_events",
+    `SELECT knowledge_id, owner, event_type, request_id, result_count
+     FROM usage_events`,
   ).all() as Array<{
-    knowledge_id: string;
+    knowledge_id: string | null;
     owner: string;
-    event_type: "exposure" | "view";
+    event_type: "query" | "exposure" | "view";
     request_id: string | null;
+    result_count: number | null;
   }>;
   const feedbackRows = db.prepare(
     "SELECT knowledge_id, owner, verdict FROM reuse_feedback",
@@ -477,14 +523,23 @@ api.get("/reports/reuse", (c) => {
     });
   }
 
-  const queryIds = new Set<string>();
+  let totalQueries = 0;
+  let queriesWithResult = 0;
   for (const row of usageRows) {
+    if (row.event_type === "query") {
+      totalQueries += 1;
+      if ((row.result_count ?? 0) > 0) {
+        queriesWithResult += 1;
+      }
+      continue;
+    }
+
+    if (!row.knowledge_id) continue;
     const item = stats.get(row.knowledge_id);
     if (!item) continue;
 
     if (row.event_type === "exposure") {
       item.exposure_count += 1;
-      if (row.request_id) queryIds.add(row.request_id);
       continue;
     }
 
@@ -564,14 +619,18 @@ api.get("/reports/reuse", (c) => {
     .map(({ reuse_score: _reuseScore, ...item }) => item);
 
   const neverAccessedPct = totalItems === 0 ? 0 : neverAccessed.length / totalItems;
-  const northStar = totalItems === 0 ? 0 : northStarCount / totalItems;
+  const northStarPct = totalItems === 0 ? 0 : northStarCount / totalItems;
+  const hitRate = totalQueries === 0 ? 0 : queriesWithResult / totalQueries;
 
   return c.json({
-    total_queries: queryIds.size,
+    total_queries: totalQueries,
+    hit_rate: hitRate,
     total_views: usageRows.filter((row) => row.event_type === "view").length,
     total_items: totalItems,
     never_accessed_pct: neverAccessedPct,
-    north_star: northStar,
+    north_star: northStarPct,
+    north_star_count: northStarCount,
+    north_star_pct: northStarPct,
     top_reused: topReused,
     never_accessed: neverAccessed,
   });

--- a/packages/backend/tests/reuse-report.test.ts
+++ b/packages/backend/tests/reuse-report.test.ts
@@ -29,9 +29,12 @@ interface TopReusedItem {
 
 interface ReuseReportResponse {
   total_queries: number;
+  hit_rate: number;
   total_views: number;
   total_items: number;
   never_accessed_pct: number;
+  north_star_count: number;
+  north_star_pct: number;
   north_star: number;
   top_reused: TopReusedItem[];
   never_accessed: NeverAccessedItem[];
@@ -79,21 +82,31 @@ function insertKnowledgeRow(
 function insertUsageEvent(
   db: Database.Database,
   input: {
-    knowledgeId: string;
+    knowledgeId?: string | null;
     owner: string;
-    eventType: "exposure" | "view";
+    eventType: "query" | "exposure" | "view";
     requestId?: string | null;
+    queryText?: string | null;
+    resultCount?: number | null;
+    project?: string;
+    searchMode?: "fts" | "semantic" | "hybrid" | null;
     queryContext?: string | null;
   },
 ): void {
   db.prepare(
-    `INSERT INTO usage_events (knowledge_id, owner, event_type, request_id, query_context)
-     VALUES (?, ?, ?, ?, ?)`,
+    `INSERT INTO usage_events (
+      knowledge_id, owner, event_type, request_id, query_text,
+      result_count, project, search_mode, query_context
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    input.knowledgeId,
+    input.knowledgeId ?? null,
     input.owner,
     input.eventType,
     input.requestId ?? null,
+    input.queryText ?? null,
+    input.resultCount ?? null,
+    input.project ?? "team-memory",
+    input.searchMode ?? null,
     input.queryContext ?? null,
   );
 }
@@ -147,12 +160,24 @@ test("reuse report aggregates total queries, views, north-star, top reused, and 
   insertKnowledgeRow(db, { id: "item-b", claim: "Usage events are mirrored before persistence." });
   insertKnowledgeRow(db, { id: "item-c", claim: "Never accessed item C." });
   insertKnowledgeRow(db, { id: "item-d", claim: "Never accessed item D." });
+  insertKnowledgeRow(db, { id: "item-e", claim: "Exposure-only item E." });
 
+  insertUsageEvent(db, {
+    owner: "Alice",
+    eventType: "query",
+    requestId: "request-1",
+    queryText: "billing ownership",
+    resultCount: 2,
+    project: "team-memory",
+    searchMode: "hybrid",
+  });
   insertUsageEvent(db, {
     knowledgeId: "item-a",
     owner: "Alice",
     eventType: "exposure",
     requestId: "request-1",
+    project: "team-memory",
+    searchMode: "hybrid",
     queryContext: "billing ownership",
   });
   insertUsageEvent(db, {
@@ -160,32 +185,78 @@ test("reuse report aggregates total queries, views, north-star, top reused, and 
     owner: "Alice",
     eventType: "exposure",
     requestId: "request-1",
+    project: "team-memory",
+    searchMode: "hybrid",
     queryContext: "billing ownership",
+  });
+
+  insertUsageEvent(db, {
+    owner: "Bob",
+    eventType: "query",
+    requestId: "request-2",
+    queryText: "usage persistence",
+    resultCount: 1,
+    project: "team-memory",
+    searchMode: "hybrid",
   });
   insertUsageEvent(db, {
     knowledgeId: "item-a",
     owner: "Bob",
     eventType: "exposure",
     requestId: "request-2",
+    project: "team-memory",
+    searchMode: "hybrid",
     queryContext: "usage persistence",
+  });
+
+  insertUsageEvent(db, {
+    owner: "Dana",
+    eventType: "query",
+    requestId: "request-3",
+    queryText: "missing topic",
+    resultCount: 0,
+    project: "team-memory",
+    searchMode: "hybrid",
+  });
+
+  insertUsageEvent(db, {
+    owner: "Eve",
+    eventType: "query",
+    requestId: "request-4",
+    queryText: "exposure only",
+    resultCount: 1,
+    project: "team-memory",
+    searchMode: "hybrid",
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "item-e",
+    owner: "Eve",
+    eventType: "exposure",
+    requestId: "request-4",
+    project: "team-memory",
+    searchMode: "hybrid",
+    queryContext: "exposure only",
   });
 
   insertUsageEvent(db, {
     knowledgeId: "item-a",
     owner: "Alice",
     eventType: "view",
+    project: "team-memory",
     queryContext: "billing ownership",
   });
   insertUsageEvent(db, {
     knowledgeId: "item-a",
     owner: "Bob",
     eventType: "view",
+    project: "team-memory",
     queryContext: "usage persistence",
   });
   insertUsageEvent(db, {
     knowledgeId: "item-b",
     owner: "Alice",
     eventType: "view",
+    project: "team-memory",
     queryContext: "billing ownership",
   });
 
@@ -211,11 +282,14 @@ test("reuse report aggregates total queries, views, north-star, top reused, and 
   assert.equal(response.status, 200);
   const body = (await response.json()) as ReuseReportResponse;
 
-  assert.equal(body.total_queries, 2);
+  assert.equal(body.total_queries, 4);
+  assert.equal(body.hit_rate, 3 / 4);
   assert.equal(body.total_views, 3);
-  assert.equal(body.total_items, 4);
-  assert.equal(body.never_accessed_pct, 0.5);
-  assert.equal(body.north_star, 0.25);
+  assert.equal(body.total_items, 5);
+  assert.equal(body.never_accessed_pct, 0.4);
+  assert.equal(body.north_star_count, 1);
+  assert.equal(body.north_star_pct, 0.2);
+  assert.equal(body.north_star, 0.2);
   assert.deepEqual(
     body.top_reused.map((item) => ({
       knowledge_id: item.knowledge_id,
@@ -260,9 +334,12 @@ test("reuse report returns zeroed metrics when there is no usage data", async ()
   const body = (await response.json()) as ReuseReportResponse;
 
   assert.equal(body.total_queries, 0);
+  assert.equal(body.hit_rate, 0);
   assert.equal(body.total_views, 0);
   assert.equal(body.total_items, 1);
   assert.equal(body.never_accessed_pct, 1);
+  assert.equal(body.north_star_count, 0);
+  assert.equal(body.north_star_pct, 0);
   assert.equal(body.north_star, 0);
   assert.deepEqual(body.top_reused, []);
   assert.deepEqual(body.never_accessed, [{ id: "lonely-item", claim: "This item has never been accessed." }]);

--- a/packages/backend/tests/reuse-tracking.test.ts
+++ b/packages/backend/tests/reuse-tracking.test.ts
@@ -16,10 +16,14 @@ process.env.EMBEDDING_API_BASE = "https://openrouter.ai/api/v1";
 process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
 
 interface UsageEventRow {
-  knowledge_id: string;
+  knowledge_id: string | null;
   owner: string;
   event_type: string;
   request_id: string | null;
+  query_text: string | null;
+  result_count: number | null;
+  project: string;
+  search_mode: string | null;
   query_context: string | null;
 }
 
@@ -121,14 +125,16 @@ test("authenticated FTS search writes exposure events with a shared request_id",
   insertKnowledgeRow(db, {
     id: "billing-row-a",
     claim: "Billing pipeline buffers usage events before persistence.",
+    project: "billing-core",
   });
   insertKnowledgeRow(db, {
     id: "billing-row-b",
     claim: "Billing ownership stays in the control plane.",
+    project: "billing-core",
   });
   const apiKey = createApiKey("Researcher");
 
-  const response = await app.request("http://localhost/api/knowledge/search?q=billing", {
+  const response = await app.request("http://localhost/api/knowledge/search?q=billing&project=billing-core", {
     headers: {
       authorization: `Bearer ${apiKey}`,
     },
@@ -137,24 +143,38 @@ test("authenticated FTS search writes exposure events with a shared request_id",
   assert.equal(response.status, 200);
 
   const events = getDb().prepare(
-    "SELECT knowledge_id, owner, event_type, request_id, query_context FROM usage_events ORDER BY knowledge_id ASC",
+    `SELECT knowledge_id, owner, event_type, request_id, query_text, result_count,
+            project, search_mode, query_context
+     FROM usage_events
+     ORDER BY id ASC`,
   ).all() as UsageEventRow[];
 
-  assert.equal(events.length, 2);
-  assert.deepEqual(events.map((event) => event.knowledge_id), ["billing-row-a", "billing-row-b"]);
-  assert.ok(events[0]!.request_id);
-  assert.equal(events[0]!.request_id, events[1]!.request_id);
+  assert.equal(events.length, 3);
+
+  const queryRow = events.find((event) => event.event_type === "query");
+  const exposureRows = events.filter((event) => event.event_type === "exposure");
+
+  assert.ok(queryRow);
+  assert.equal(queryRow!.knowledge_id, null);
+  assert.equal(queryRow!.owner, "Researcher");
+  assert.equal(queryRow!.query_text, "billing");
+  assert.equal(queryRow!.result_count, 2);
+  assert.equal(queryRow!.project, "billing-core");
+  assert.equal(queryRow!.search_mode, "hybrid");
+  assert.equal(queryRow!.query_context, null);
+
+  assert.equal(exposureRows.length, 2);
   assert.deepEqual(
-    events.map((event) => ({
-      owner: event.owner,
-      event_type: event.event_type,
-      query_context: event.query_context,
-    })),
-    [
-      { owner: "Researcher", event_type: "exposure", query_context: "billing" },
-      { owner: "Researcher", event_type: "exposure", query_context: "billing" },
-    ],
+    exposureRows.map((event) => event.knowledge_id).sort(),
+    ["billing-row-a", "billing-row-b"],
   );
+  assert.ok(queryRow!.request_id);
+  assert.ok(exposureRows.every((event) => event.request_id === queryRow!.request_id));
+  assert.ok(exposureRows.every((event) => event.project === "billing-core"));
+  assert.ok(exposureRows.every((event) => event.search_mode === "hybrid"));
+  assert.ok(exposureRows.every((event) => event.query_text === null));
+  assert.ok(exposureRows.every((event) => event.result_count === null));
+  assert.ok(exposureRows.every((event) => event.query_context === "billing"));
 });
 
 test("authenticated semantic search writes exposure events with query context", async () => {
@@ -185,15 +205,34 @@ test("authenticated semantic search writes exposure events with query context", 
   assert.equal(response.status, 200);
 
   const events = getDb().prepare(
-    "SELECT knowledge_id, owner, event_type, request_id, query_context FROM usage_events",
+    `SELECT knowledge_id, owner, event_type, request_id, query_text, result_count,
+            project, search_mode, query_context
+     FROM usage_events
+     ORDER BY id ASC`,
   ).all() as UsageEventRow[];
 
-  assert.equal(events.length, 1);
-  assert.equal(events[0]!.knowledge_id, "semantic-row");
-  assert.equal(events[0]!.owner, "SemanticUser");
-  assert.equal(events[0]!.event_type, "exposure");
-  assert.ok(events[0]!.request_id);
-  assert.equal(events[0]!.query_context, "usage mirroring");
+  assert.equal(events.length, 2);
+
+  const queryRow = events.find((event) => event.event_type === "query");
+  const exposureRow = events.find((event) => event.event_type === "exposure");
+
+  assert.ok(queryRow);
+  assert.ok(exposureRow);
+  assert.equal(queryRow!.knowledge_id, null);
+  assert.equal(queryRow!.owner, "SemanticUser");
+  assert.equal(queryRow!.query_text, "usage mirroring");
+  assert.equal(queryRow!.result_count, 1);
+  assert.equal(queryRow!.project, "");
+  assert.equal(queryRow!.search_mode, "semantic");
+  assert.ok(queryRow!.request_id);
+
+  assert.equal(exposureRow!.knowledge_id, "semantic-row");
+  assert.equal(exposureRow!.owner, "SemanticUser");
+  assert.equal(exposureRow!.event_type, "exposure");
+  assert.equal(exposureRow!.request_id, queryRow!.request_id);
+  assert.equal(exposureRow!.project, "team-memory");
+  assert.equal(exposureRow!.search_mode, "semantic");
+  assert.equal(exposureRow!.query_context, "usage mirroring");
 });
 
 test("authenticated get_knowledge writes a view event and stores query_context", async () => {
@@ -216,14 +255,49 @@ test("authenticated get_knowledge writes a view event and stores query_context",
   assert.equal(response.status, 200);
 
   const event = getDb().prepare(
-    "SELECT knowledge_id, owner, event_type, request_id, query_context FROM usage_events",
+    `SELECT knowledge_id, owner, event_type, request_id, query_text, result_count,
+            project, search_mode, query_context
+     FROM usage_events`,
   ).get() as UsageEventRow;
 
   assert.equal(event.knowledge_id, "view-row");
   assert.equal(event.owner, "Viewer");
   assert.equal(event.event_type, "view");
   assert.equal(event.request_id, null);
+  assert.equal(event.project, "team-memory");
+  assert.equal(event.query_text, null);
+  assert.equal(event.result_count, null);
+  assert.equal(event.search_mode, null);
   assert.equal(event.query_context, "task:billing-investigation");
+});
+
+test("authenticated 0-hit search still writes a query row with result_count 0", async () => {
+  const apiKey = createApiKey("NoHitUser");
+
+  const response = await app.request("http://localhost/api/knowledge/search?q=missingtopic&project=ghost-project", {
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  assert.equal(response.status, 200);
+
+  const events = getDb().prepare(
+    `SELECT knowledge_id, owner, event_type, request_id, query_text, result_count,
+            project, search_mode, query_context
+     FROM usage_events`,
+  ).all() as UsageEventRow[];
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.event_type, "query");
+  assert.equal(events[0]!.knowledge_id, null);
+  assert.equal(events[0]!.owner, "NoHitUser");
+  assert.equal(events[0]!.query_text, "missingtopic");
+  assert.equal(events[0]!.result_count, 0);
+  assert.equal(events[0]!.project, "ghost-project");
+  assert.equal(events[0]!.search_mode, "hybrid");
+  assert.equal(events[0]!.query_context, null);
+  assert.ok(events[0]!.request_id);
 });
 
 test("authenticated feedback endpoint persists reuse feedback", async () => {

--- a/packages/backend/tests/reuse-tracking.test.ts
+++ b/packages/backend/tests/reuse-tracking.test.ts
@@ -235,6 +235,49 @@ test("authenticated semantic search writes exposure events with query context", 
   assert.equal(exposureRow!.query_context, "usage mirroring");
 });
 
+test("authenticated semantic search still writes a query row when query embedding generation fails", async () => {
+  const apiKey = createApiKey("SemanticFallback");
+
+  globalThis.fetch = (async () => new Response(
+    JSON.stringify({ error: "provider unavailable" }),
+    {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    },
+  )) as typeof globalThis.fetch;
+
+  const response = await app.request(
+    "http://localhost/api/knowledge/semantic-search?q=semantic%20fallback&project=team-memory",
+    {
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { items: unknown[]; total: number };
+  assert.equal(body.total, 0);
+  assert.deepEqual(body.items, []);
+
+  const events = getDb().prepare(
+    `SELECT knowledge_id, owner, event_type, request_id, query_text, result_count,
+            project, search_mode, query_context
+     FROM usage_events`,
+  ).all() as UsageEventRow[];
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.knowledge_id, null);
+  assert.equal(events[0]!.owner, "SemanticFallback");
+  assert.equal(events[0]!.event_type, "query");
+  assert.ok(events[0]!.request_id);
+  assert.equal(events[0]!.query_text, "semantic fallback");
+  assert.equal(events[0]!.result_count, 0);
+  assert.equal(events[0]!.project, "team-memory");
+  assert.equal(events[0]!.search_mode, "semantic");
+  assert.equal(events[0]!.query_context, null);
+});
+
 test("authenticated get_knowledge writes a view event and stores query_context", async () => {
   const db = getDb();
   insertKnowledgeRow(db, {


### PR DESCRIPTION
## Summary
- make `query` a first-class `usage_events` row with raw `query_text`, `result_count`, `project`, and shared `request_id`
- write `query + exposure` rows for authenticated search / semantic-search and persist `project` on `view` rows
- restore `hit_rate` in `/api/reports/reuse`, add `north_star_count` + `north_star_pct`, and keep `never_accessed` on the original P0 semantics (`no exposure / view / feedback`)
- update backend tests to lock the new query-row model, 0-hit observability, and the old `never_accessed` definition

## Contract Notes
- `usage_events.event_type` is now `query | exposure | view`
- `reuse_feedback` remains a separate first-class record
- `query_text` is stored raw; normalization is still deferred to report aggregation in M1b
- `never_accessed` is intentionally **not** redefined to view-only in this PR

## Verification
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" npm run test --workspace=packages/backend`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" npm run build --workspace=packages/backend`
