### PR TITLE
P0.1 / M1-docs: align three integration docs to v3.1 (query first-class, north_star deprecated)

### DIFF
--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -4,20 +4,39 @@ This document defines how agents should interact with Team Memory in their daily
 
 ## How Team Memory Measures Reuse
 
-Every interaction with a knowledge item is recorded so we can tell whether the system is actually saving work. The model uses four terms — learn these names, they show up in tool descriptions, reports, and the dashboard.
+Every interaction with a knowledge item is recorded so we can tell whether the system is actually saving work. The model has **four first-class tracked interactions** — learn these names, they show up in tool descriptions, reports, and the dashboard.
 
 | Term | How it's produced | What it means |
 |------|-------------------|---------------|
-| **query** | You call `query_knowledge` or `semantic_search`. Derived, not stored directly — counted as `COUNT(DISTINCT request_id)` over exposure rows | You asked the team's memory a question |
-| **exposure** | An `exposure` row is written for each item returned in your search results | The item was offered to you but you may not have opened it |
-| **view** | A `view` row is written when you call `get_knowledge` on an item | You opened the full detail — a weak reuse signal |
-| **feedback** | A row is written in the `reuse_feedback` table when you call the `reuse_feedback` tool | You explicitly told the system whether the item helped — the strong reuse signal |
+| **query** | You call `query_knowledge` or `semantic_search`. Each call writes one `usage_events` row with `event_type='query'`, the raw `query_text`, the `result_count`, the `project`, and a `search_mode` (`fts` / `semantic` / `hybrid`) | You asked the team's memory a question — including 0-hit searches and searches whose embedding generation failed |
+| **exposure** | One `usage_events` row with `event_type='exposure'` is written for each item returned in your search results, sharing the same `request_id` as its parent `query` row | The item was offered to you but you may not have opened it |
+| **view** | A `usage_events` row with `event_type='view'` is written when you call `get_knowledge` on an item | You opened the full detail — a weak reuse signal |
+| **feedback** | A row is written in the dedicated `reuse_feedback` table when you call the `reuse_feedback` tool | You explicitly told the system whether the item helped — the strong reuse signal |
 
-Only `exposure`, `view`, and `feedback` are persisted as first-class rows in P0. `query` is derived from shared `request_id`s across exposure rows, so **0-hit searches are not counted in P0** — that's why the reports do not yet include a `hit_rate` metric.
+In P0.1, `query` is a first-class row in `usage_events` (alongside `exposure` and `view`); `feedback` is a separate first-class table. So the schema persists **3 event types in `usage_events` plus 1 first-class `reuse_feedback` record** — please do not call this "four event types", it implies feedback is in the `event_type` enum.
+
+This is a reversal of the earlier P0 design that derived `query` from `COUNT(DISTINCT request_id)` over `exposure` rows. The reversal makes 0-hit and failed-embedding searches observable, which is why the reuse report now exposes `total_queries` and `hit_rate`.
 
 Reports prioritize `view` + `feedback` over `exposure` for the real reuse metrics (north star, top reused). Exposure is tracked for search-effectiveness analysis only.
 
 **Practical takeaway:** every `get_knowledge` should be followed by a `reuse_feedback` once you know whether it helped. Without feedback, the team only sees weak signals.
+
+### What the reuse report exposes
+
+`GET /api/reports/reuse` returns the team-wide reuse snapshot. The fields you'll see today:
+
+| Field | Meaning |
+|-------|---------|
+| `total_queries` | Count of `query` rows. Includes 0-hit and failed-embedding queries |
+| `hit_rate` | `queries_with_result / total_queries`. `0` when there are no queries |
+| `total_views` | Count of `view` rows |
+| `total_items` | Total knowledge rows in the table |
+| `never_accessed` | Items with **no** `exposure`, `view`, or `feedback` (P0 original semantic — kept stable on purpose, not silently redefined) |
+| `never_accessed_pct` | `never_accessed.length / total_items` |
+| `north_star_count` | Items used by ≥ 2 distinct owners via `view` or `useful` feedback |
+| `north_star_pct` | `north_star_count / total_items` |
+| `north_star` | **Deprecated** — back-compat alias for `north_star_pct`. New code should read `north_star_pct` (and/or `north_star_count`); this field will be removed in a future release |
+| `top_reused` | Top 10 items by `view_count + useful_feedback_count`, with per-owner uniqueness tiebreaker |
 
 ## Core Workflow
 

--- a/docs/mcp-config-template.md
+++ b/docs/mcp-config-template.md
@@ -64,14 +64,16 @@ Once connected, your agent will have access to:
 | Tool | Purpose |
 |------|---------|
 | `publish_knowledge` | Share a finding with the team |
-| `query_knowledge` | Search knowledge by keywords (FTS5). Each returned item is logged as an `exposure` row (sharing a `request_id`); the query count is derived from distinct `request_id`s |
-| `semantic_search` | Search knowledge by meaning using vector similarity — finds conceptually related items even when exact words differ. Same event semantics as `query_knowledge` |
+| `query_knowledge` | Search knowledge by keywords (FTS5). Each call writes one first-class `query` event (with raw `query_text`, `result_count`, `project`, `search_mode`) and one `exposure` event per returned item — all sharing the same `request_id`. 0-hit searches still write the `query` row so they remain observable |
+| `semantic_search` | Search knowledge by meaning using vector similarity — finds conceptually related items even when exact words differ. Same event semantics as `query_knowledge`. Failed embedding generation still writes a `query` row with `result_count=0` and `search_mode='semantic'` so the attempt is not silently dropped |
 | `list_knowledge` | Browse knowledge by project/tags |
-| `get_knowledge` | Read full detail of a knowledge item — produces a `view` event. Pass optional `query_context` to label why you opened it |
+| `get_knowledge` | Read full detail of a knowledge item — produces a `view` event (carries the item's `project`). Pass optional `query_context` to label why you opened it |
 | `reuse_feedback` | After using an item, report `useful` / `not_useful` / `outdated`. This is the **strong reuse signal** that drives the team's north-star metric |
 | `update_knowledge` | Update metadata (tags, confidence, staleness, related_to) |
 
-> **Reuse tracking requires an authenticated API key.** Unauthenticated reads still work, but the backend cannot attribute `exposure` / `view` events to a specific agent, so those interactions won't appear in reuse reports. Always configure `TEAM_MEMORY_API_KEY` to be counted.
+> **Reuse tracking requires an authenticated API key.** Unauthenticated reads still work, but the backend cannot attribute `query` / `exposure` / `view` events to a specific agent, so those interactions won't appear in reuse reports. Always configure `TEAM_MEMORY_API_KEY` to be counted.
+
+> **Terminology — 4 first-class tracked interactions, but not 4 `event_type` values.** The schema has 3 event types in `usage_events` (`query` / `exposure` / `view`) plus a separate first-class `reuse_feedback` table. Please use "four first-class tracked interactions" (or list the names) rather than "four event types".
 
 ## Verification
 

--- a/docs/system-prompt-snippet.md
+++ b/docs/system-prompt-snippet.md
@@ -18,6 +18,8 @@ You have access to a shared team knowledge base via the Team Memory MCP tools. U
 3. If results are found, call `get_knowledge` to read the full detail. Pass `query_context` describing what task prompted the view.
 4. Use existing knowledge as context. Do not redo analysis that has already been published.
 
+> Every search call (including 0-hit searches and searches whose embedding generation fails) is recorded as a first-class `query` event. Don't skip a search because "it might come back empty" — empty searches are how the team learns what knowledge is missing.
+
 ### After using a knowledge item
 
 Every `get_knowledge` call should be followed by a `reuse_feedback` call once you know whether the item helped:
@@ -26,7 +28,7 @@ Every `get_knowledge` call should be followed by a `reuse_feedback` call once yo
 - `not_useful` — irrelevant to your task, or the claim was wrong.
 - `outdated` — used to be true but no longer applies (consider also publishing a superseding item).
 
-Skipping feedback means the team can't measure which knowledge is actually valuable. Treat `reuse_feedback` as mandatory, not optional.
+`reuse_feedback` is a separate first-class record, not a tag on the view event — it is how the team computes the strong reuse signal (per `(owner, knowledge_id)` pair). Skipping feedback means the team can't measure which knowledge is actually valuable. Treat it as mandatory, not optional.
 
 ### After completing a task
 


### PR DESCRIPTION
## Summary

Fan-out doc work for the P0.1 / M1a backend reversal that landed in #32. The three integration docs were still describing the older P0 model where `query` was a derived count over `exposure` `request_id`s. After M1a, `query` is a first-class row in `usage_events` with raw `query_text`, `result_count`, `project`, and `search_mode`, so the docs need to match.

This PR is **docs only** — no code changes.

### What changed

- **`docs/agent-protocol.md`**
  - "How Team Memory Measures Reuse" rewritten: the model is now framed as **four first-class tracked interactions**, with an explicit note that the schema persists **3 event types in `usage_events` (`query` / `exposure` / `view`) plus 1 first-class `reuse_feedback` record**. Please don't call this "four event types" — `feedback` is not in the `event_type` enum, that phrasing implies it is.
  - One paragraph on the historical P0 → P0.1 reversal so readers can place the change in context.
  - New **"What the reuse report exposes"** subsection covering the current `/api/reports/reuse` fields. Marks the legacy `north_star` field as **Deprecated** (it is now an alias for `north_star_pct`, kept for back-compat, slated for removal).
  - Pins `never_accessed` to its **P0 original meaning** (no `exposure` / `view` / `feedback`) and explicitly calls out that we intentionally did not silently redefine it (the principled stance Jet pushed for; backed by the architect after the round of back-and-forth on the v3 lock).

- **`docs/mcp-config-template.md`**
  - `query_knowledge` / `semantic_search` rows rewritten: each authenticated call writes one first-class `query` row (with the locked field set) plus N `exposure` rows sharing `request_id`. 0-hit and failed-embedding queries still write the `query` row.
  - Updated auth callout to enumerate `query` / `exposure` / `view` as the events that require an authenticated key.
  - Added a **terminology note** that points contributors away from "four event types" and toward "four first-class tracked interactions".

- **`docs/system-prompt-snippet.md`**
  - One-paragraph nudge for agents: don't skip a search because it might come back empty — empty searches are now first-class signals about missing knowledge.
  - Clarified `reuse_feedback` is a separate first-class record (per `(owner, knowledge_id)` pair), not a tag on the view event — this prevents the common misread that feedback is a `usage_events.event_type` value.

### Out of scope (intentional)

- M1b additions (`?since=`, `?project=`, `?min_age_days=`, `feedback_coverage`, `top_0hit_keywords`) — those will land in #41 and the docs follow-up will be a separate small PR after that merges. Keeping this PR aligned strictly to **what is in `main` today**.
- MCP tool descriptions inside `packages/mcp-server/src/index.ts` are being updated by @Ed in #34 / #43 — this PR does not touch that file. The two PRs are designed to land in either order.

### Reviewers

- **Wording:** @Jet (per the v3.1 lock — terminology consistency with #34 / #43)
- **Architecture / contract:** I (Spike) wrote it; if you'd like a second contract pair of eyes, @Ein is welcome to skim, but it's not required.

## Test plan

- [ ] @Jet verifies "four first-class tracked interactions" wording is used consistently across the three docs and matches the wording landing in #34
- [ ] Verify that no remaining occurrence of the old "query is derived" language exists in the three doc files
- [ ] Verify the `never_accessed` definition in the report-fields table matches the M1a backend implementation (no `exposure` / `view` / `feedback`)
- [ ] Verify the deprecation note on `north_star` matches the actual API response shape (still emitted, equals `north_star_pct`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)