### PR TITLE
P0.1 M1b: enhance reuse report filters and metrics

### DIFF
--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -644,23 +644,29 @@ api.get("/reports/reuse", (c) => {
   }
 
   const totalItems = knowledgeRows.length;
+  const baseNeverAccessed = knowledgeRows.filter((row) => {
+    const item = stats.get(row.id);
+    if (!item) return false;
+    return (
+      item.exposure_count === 0
+      && item.view_count === 0
+      && item.useful_feedback_count === 0
+      && item.not_useful_feedback_count === 0
+      && item.outdated_feedback_count === 0
+    );
+  });
+
   const minCreatedAtTimestamp = minAgeDays === null
     ? null
     : Date.now() - minAgeDays * 24 * 60 * 60 * 1000;
-  const neverAccessed = knowledgeRows
+  const neverAccessed = baseNeverAccessed
     .filter((row) => {
       if (minCreatedAtTimestamp !== null && timestampFromDb(row.created_at) > minCreatedAtTimestamp) {
         return false;
       }
       const item = stats.get(row.id);
       if (!item) return false;
-      return (
-        item.exposure_count === 0
-        && item.view_count === 0
-        && item.useful_feedback_count === 0
-        && item.not_useful_feedback_count === 0
-        && item.outdated_feedback_count === 0
-      );
+      return true;
     })
     .map((row) => ({ id: row.id, claim: row.claim }));
 
@@ -737,7 +743,7 @@ api.get("/reports/reuse", (c) => {
     .slice(0, 10)
     .map(({ reuse_score: _reuseScore, ...item }) => item);
 
-  const neverAccessedPct = totalItems === 0 ? 0 : neverAccessed.length / totalItems;
+  const neverAccessedPct = totalItems === 0 ? 0 : baseNeverAccessed.length / totalItems;
   const northStarPct = totalItems === 0 ? 0 : northStarCount / totalItems;
   const hitRate = totalQueries === 0 ? 0 : queriesWithResult / totalQueries;
   const coveredPairs = Array.from(viewedPairs).filter((pairKey) => feedbackPairs.has(pairKey)).length;

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -75,6 +75,17 @@ function parseTagList(tags: string | null | undefined): string[] | undefined {
   return list.length > 0 ? list : undefined;
 }
 
+function timestampFromDb(value: string): number {
+  const normalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(value)
+    ? `${value.replace(" ", "T")}Z`
+    : value;
+  return Date.parse(normalized);
+}
+
+function normalizeQueryText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
 function matchesRequestedTags(row: KnowledgeRow, tags: string[] | undefined): boolean {
   if (!tags || tags.length === 0) return true;
   const rowTags: string[] = JSON.parse(row.tags).map((tag: string) => tag.toLowerCase());
@@ -485,27 +496,86 @@ api.get("/knowledge/:id", (c) => {
 
 // 6. GET /api/reports/reuse
 api.get("/reports/reuse", (c) => {
+  const since = c.req.query("since");
+  const project = c.req.query("project");
+  const minAgeDaysParam = c.req.query("min_age_days");
+  let cutoffTimestamp: number | null = null;
+  if (since) {
+    const match = /^(\d+)d$/.exec(since.trim());
+    if (!match) {
+      return c.json({ error: "since must be in Nd format, for example 7d or 30d" }, 400);
+    }
+    cutoffTimestamp = Date.now() - Number.parseInt(match[1]!, 10) * 24 * 60 * 60 * 1000;
+  }
+
+  let minAgeDays: number | null = null;
+  if (minAgeDaysParam) {
+    const parsed = Number.parseInt(minAgeDaysParam, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return c.json({ error: "min_age_days must be a non-negative integer" }, 400);
+    }
+    minAgeDays = parsed;
+  }
+
   const db = getDb();
+  const knowledgeParams: string[] = [];
+  const knowledgeWhere: string[] = [];
+  if (project) {
+    knowledgeWhere.push("project = ?");
+    knowledgeParams.push(project);
+  }
   const knowledgeRows = db.prepare(
-    "SELECT id, claim, created_at FROM knowledge ORDER BY created_at ASC",
-  ).all() as Array<{ id: string; claim: string; created_at: string }>;
+    `SELECT id, claim, project, created_at
+     FROM knowledge
+     ${knowledgeWhere.length > 0 ? `WHERE ${knowledgeWhere.join(" AND ")}` : ""}
+     ORDER BY created_at ASC`,
+  ).all(...knowledgeParams) as Array<{ id: string; claim: string; project: string; created_at: string }>;
+
+  const usageParams: string[] = [];
+  const usageWhere: string[] = [];
+  if (project) {
+    usageWhere.push("project = ?");
+    usageParams.push(project);
+  }
   const usageRows = db.prepare(
-    `SELECT knowledge_id, owner, event_type, request_id, result_count
-     FROM usage_events`,
-  ).all() as Array<{
+    `SELECT knowledge_id, owner, event_type, request_id, query_text, result_count, project, created_at
+     FROM usage_events
+     ${usageWhere.length > 0 ? `WHERE ${usageWhere.join(" AND ")}` : ""}`,
+  ).all(...usageParams) as Array<{
     knowledge_id: string | null;
     owner: string;
     event_type: "query" | "exposure" | "view";
     request_id: string | null;
+    query_text: string | null;
     result_count: number | null;
+    project: string;
+    created_at: string;
   }>;
+
+  const feedbackParams: string[] = [];
+  const feedbackWhere: string[] = [];
+  if (project) {
+    feedbackWhere.push("knowledge.project = ?");
+    feedbackParams.push(project);
+  }
   const feedbackRows = db.prepare(
-    "SELECT knowledge_id, owner, verdict FROM reuse_feedback",
-  ).all() as Array<{
+    `SELECT reuse_feedback.knowledge_id, reuse_feedback.owner, reuse_feedback.verdict, reuse_feedback.created_at
+     FROM reuse_feedback
+     JOIN knowledge ON knowledge.id = reuse_feedback.knowledge_id
+     ${feedbackWhere.length > 0 ? `WHERE ${feedbackWhere.join(" AND ")}` : ""}`,
+  ).all(...feedbackParams) as Array<{
     knowledge_id: string;
     owner: string;
     verdict: ReuseVerdict;
+    created_at: string;
   }>;
+
+  const filteredUsageRows = usageRows.filter((row) => (
+    cutoffTimestamp === null || timestampFromDb(row.created_at) >= cutoffTimestamp
+  ));
+  const filteredFeedbackRows = feedbackRows.filter((row) => (
+    cutoffTimestamp === null || timestampFromDb(row.created_at) >= cutoffTimestamp
+  ));
 
   const stats = new Map<string, {
     claim: string;
@@ -533,7 +603,8 @@ api.get("/reports/reuse", (c) => {
 
   let totalQueries = 0;
   let queriesWithResult = 0;
-  for (const row of usageRows) {
+  const viewedPairs = new Set<string>();
+  for (const row of filteredUsageRows) {
     if (row.event_type === "query") {
       totalQueries += 1;
       if ((row.result_count ?? 0) > 0) {
@@ -553,11 +624,14 @@ api.get("/reports/reuse", (c) => {
 
     item.view_count += 1;
     item.view_owners.add(row.owner);
+    viewedPairs.add(`${row.owner}\u0000${row.knowledge_id}`);
   }
 
-  for (const row of feedbackRows) {
+  const feedbackPairs = new Set<string>();
+  for (const row of filteredFeedbackRows) {
     const item = stats.get(row.knowledge_id);
     if (!item) continue;
+    feedbackPairs.add(`${row.owner}\u0000${row.knowledge_id}`);
 
     if (row.verdict === "useful") {
       item.useful_feedback_count += 1;
@@ -570,8 +644,14 @@ api.get("/reports/reuse", (c) => {
   }
 
   const totalItems = knowledgeRows.length;
+  const minCreatedAtTimestamp = minAgeDays === null
+    ? null
+    : Date.now() - minAgeDays * 24 * 60 * 60 * 1000;
   const neverAccessed = knowledgeRows
     .filter((row) => {
+      if (minCreatedAtTimestamp !== null && timestampFromDb(row.created_at) > minCreatedAtTimestamp) {
+        return false;
+      }
       const item = stats.get(row.id);
       if (!item) return false;
       return (
@@ -583,6 +663,37 @@ api.get("/reports/reuse", (c) => {
       );
     })
     .map((row) => ({ id: row.id, claim: row.claim }));
+
+  const top0HitKeywords = Array.from(
+    filteredUsageRows
+      .filter((row) => row.event_type === "query" && (row.result_count ?? 0) === 0 && row.query_text)
+      .reduce((acc, row) => {
+        const rawQuery = row.query_text!.trim();
+        const normalizedKey = normalizeQueryText(row.query_text!);
+        if (!normalizedKey) return acc;
+
+        const existing = acc.get(normalizedKey);
+        if (existing) {
+          existing.query_count += 1;
+          return acc;
+        }
+
+        acc.set(normalizedKey, {
+          normalized_key: normalizedKey,
+          example_text: rawQuery,
+          query_count: 1,
+        });
+        return acc;
+      }, new Map<string, { normalized_key: string; example_text: string; query_count: number }>())
+      .values(),
+  )
+    .sort((left, right) => {
+      if (right.query_count !== left.query_count) {
+        return right.query_count - left.query_count;
+      }
+      return left.example_text.localeCompare(right.example_text);
+    })
+    .slice(0, 10);
 
   const northStarCount = knowledgeRows.filter((row) => {
     const item = stats.get(row.id);
@@ -629,17 +740,21 @@ api.get("/reports/reuse", (c) => {
   const neverAccessedPct = totalItems === 0 ? 0 : neverAccessed.length / totalItems;
   const northStarPct = totalItems === 0 ? 0 : northStarCount / totalItems;
   const hitRate = totalQueries === 0 ? 0 : queriesWithResult / totalQueries;
+  const coveredPairs = Array.from(viewedPairs).filter((pairKey) => feedbackPairs.has(pairKey)).length;
+  const feedbackCoverage = viewedPairs.size === 0 ? 0 : coveredPairs / viewedPairs.size;
 
   return c.json({
     total_queries: totalQueries,
     hit_rate: hitRate,
-    total_views: usageRows.filter((row) => row.event_type === "view").length,
+    total_views: filteredUsageRows.filter((row) => row.event_type === "view").length,
     total_items: totalItems,
     never_accessed_pct: neverAccessedPct,
+    feedback_coverage: feedbackCoverage,
     north_star: northStarPct,
     north_star_count: northStarCount,
     north_star_pct: northStarPct,
     top_reused: topReused,
+    top_0hit_keywords: top0HitKeywords,
     never_accessed: neverAccessed,
   });
 });

--- a/packages/backend/tests/reuse-report.test.ts
+++ b/packages/backend/tests/reuse-report.test.ts
@@ -549,3 +549,27 @@ test("reuse report applies min_age_days only to never_accessed", async () => {
     { id: "old-never-accessed", claim: "Old untouched item." },
   ]);
 });
+
+test("reuse report keeps never_accessed_pct on the unfiltered baseline when min_age_days is set", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "older-never-accessed",
+    claim: "Older untouched item.",
+    createdAt: daysAgo(30),
+  });
+  insertKnowledgeRow(db, {
+    id: "younger-never-accessed",
+    claim: "Younger untouched item.",
+    createdAt: daysAgo(2),
+  });
+
+  const response = await app.request(
+    "http://localhost/api/reports/reuse?min_age_days=7",
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as ReuseReportResponse;
+
+  assert.equal(body.never_accessed.length, 1);
+  assert.equal(body.never_accessed_pct, 1);
+});

--- a/packages/backend/tests/reuse-report.test.ts
+++ b/packages/backend/tests/reuse-report.test.ts
@@ -544,7 +544,7 @@ test("reuse report applies min_age_days only to never_accessed", async () => {
   const body = (await response.json()) as ReuseReportResponse;
 
   assert.equal(body.total_items, 2);
-  assert.equal(body.never_accessed_pct, 0.5);
+  assert.equal(body.never_accessed_pct, 1);
   assert.deepEqual(body.never_accessed, [
     { id: "old-never-accessed", claim: "Old untouched item." },
   ]);

--- a/packages/backend/tests/reuse-report.test.ts
+++ b/packages/backend/tests/reuse-report.test.ts
@@ -33,11 +33,21 @@ interface ReuseReportResponse {
   total_views: number;
   total_items: number;
   never_accessed_pct: number;
+  feedback_coverage?: number;
   north_star_count: number;
   north_star_pct: number;
   north_star: number;
   top_reused: TopReusedItem[];
+  top_0hit_keywords?: Array<{
+    normalized_key: string;
+    example_text: string;
+    query_count: number;
+  }>;
   never_accessed: NeverAccessedItem[];
+}
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 }
 
 let app: Hono;
@@ -49,9 +59,10 @@ function insertKnowledgeRow(
   input: {
     id: string;
     claim: string;
+    project?: string;
+    createdAt?: string;
   },
 ): void {
-  const now = new Date().toISOString();
   db.prepare(
     `INSERT INTO knowledge (
       id, claim, detail, source, project, module, tags, confidence,
@@ -63,7 +74,7 @@ function insertKnowledgeRow(
     input.claim,
     null,
     JSON.stringify(["tests/reuse-report.test.ts"]),
-    "team-memory",
+    input.project ?? "team-memory",
     "reuse-report",
     JSON.stringify(["reuse"]),
     "high",
@@ -74,8 +85,8 @@ function insertKnowledgeRow(
     null,
     null,
     null,
-    now,
-    now,
+    input.createdAt ?? new Date().toISOString(),
+    input.createdAt ?? new Date().toISOString(),
   );
 }
 
@@ -91,13 +102,14 @@ function insertUsageEvent(
     project?: string;
     searchMode?: "fts" | "semantic" | "hybrid" | null;
     queryContext?: string | null;
+    createdAt?: string;
   },
 ): void {
   db.prepare(
     `INSERT INTO usage_events (
       knowledge_id, owner, event_type, request_id, query_text,
-      result_count, project, search_mode, query_context
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      result_count, project, search_mode, query_context, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     input.knowledgeId ?? null,
     input.owner,
@@ -108,6 +120,7 @@ function insertUsageEvent(
     input.project ?? "team-memory",
     input.searchMode ?? null,
     input.queryContext ?? null,
+    input.createdAt ?? new Date().toISOString(),
   );
 }
 
@@ -118,16 +131,18 @@ function insertFeedback(
     owner: string;
     verdict: "useful" | "not_useful" | "outdated";
     comment?: string | null;
+    createdAt?: string;
   },
 ): void {
   db.prepare(
-    `INSERT INTO reuse_feedback (knowledge_id, owner, verdict, comment)
-     VALUES (?, ?, ?, ?)`,
+    `INSERT INTO reuse_feedback (knowledge_id, owner, verdict, comment, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
   ).run(
     input.knowledgeId,
     input.owner,
     input.verdict,
     input.comment ?? null,
+    input.createdAt ?? new Date().toISOString(),
   );
 }
 
@@ -343,4 +358,194 @@ test("reuse report returns zeroed metrics when there is no usage data", async ()
   assert.equal(body.north_star, 0);
   assert.deepEqual(body.top_reused, []);
   assert.deepEqual(body.never_accessed, [{ id: "lonely-item", claim: "This item has never been accessed." }]);
+});
+
+test("reuse report supports since/project filters, pair coverage, and normalized 0-hit keywords", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "team-item-a",
+    claim: "Billing events fan out before persistence.",
+    project: "team-memory",
+    createdAt: daysAgo(20),
+  });
+  insertKnowledgeRow(db, {
+    id: "team-item-b",
+    claim: "Cache invalidation requires explicit owner handoff.",
+    project: "team-memory",
+    createdAt: daysAgo(15),
+  });
+  insertKnowledgeRow(db, {
+    id: "infer-item",
+    claim: "Inference project item.",
+    project: "infer-monorepo",
+    createdAt: daysAgo(15),
+  });
+
+  insertUsageEvent(db, {
+    owner: "Alice",
+    eventType: "query",
+    requestId: "recent-hit",
+    queryText: "Billing Refund",
+    resultCount: 1,
+    project: "team-memory",
+    searchMode: "hybrid",
+    createdAt: daysAgo(2),
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "team-item-a",
+    owner: "Alice",
+    eventType: "exposure",
+    requestId: "recent-hit",
+    project: "team-memory",
+    searchMode: "hybrid",
+    queryContext: "Billing Refund",
+    createdAt: daysAgo(2),
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "team-item-a",
+    owner: "Alice",
+    eventType: "view",
+    project: "team-memory",
+    queryContext: "Billing Refund",
+    createdAt: daysAgo(2),
+  });
+  insertFeedback(db, {
+    knowledgeId: "team-item-a",
+    owner: "Alice",
+    verdict: "useful",
+    createdAt: daysAgo(2),
+  });
+  insertFeedback(db, {
+    knowledgeId: "team-item-a",
+    owner: "Alice",
+    verdict: "useful",
+    createdAt: daysAgo(1),
+  });
+
+  insertUsageEvent(db, {
+    owner: "Alice",
+    eventType: "query",
+    requestId: "recent-zero-hit-1",
+    queryText: "Refund",
+    resultCount: 0,
+    project: "team-memory",
+    searchMode: "hybrid",
+    createdAt: daysAgo(1),
+  });
+  insertUsageEvent(db, {
+    owner: "Bob",
+    eventType: "query",
+    requestId: "recent-zero-hit-2",
+    queryText: "refund ",
+    resultCount: 0,
+    project: "team-memory",
+    searchMode: "hybrid",
+    createdAt: daysAgo(1),
+  });
+
+  insertUsageEvent(db, {
+    owner: "Carol",
+    eventType: "query",
+    requestId: "recent-other-project",
+    queryText: "Billing Refund",
+    resultCount: 1,
+    project: "infer-monorepo",
+    searchMode: "hybrid",
+    createdAt: daysAgo(1),
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "infer-item",
+    owner: "Carol",
+    eventType: "exposure",
+    requestId: "recent-other-project",
+    project: "infer-monorepo",
+    searchMode: "hybrid",
+    queryContext: "Billing Refund",
+    createdAt: daysAgo(1),
+  });
+
+  insertUsageEvent(db, {
+    owner: "LegacyUser",
+    eventType: "query",
+    requestId: "old-query",
+    queryText: "Old hit",
+    resultCount: 1,
+    project: "team-memory",
+    searchMode: "hybrid",
+    createdAt: daysAgo(45),
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "team-item-b",
+    owner: "LegacyUser",
+    eventType: "exposure",
+    requestId: "old-query",
+    project: "team-memory",
+    searchMode: "hybrid",
+    queryContext: "Old hit",
+    createdAt: daysAgo(45),
+  });
+  insertUsageEvent(db, {
+    knowledgeId: "team-item-b",
+    owner: "LegacyUser",
+    eventType: "view",
+    project: "team-memory",
+    queryContext: "Old hit",
+    createdAt: daysAgo(45),
+  });
+
+  const response = await app.request(
+    "http://localhost/api/reports/reuse?since=7d&project=team-memory",
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as ReuseReportResponse;
+
+  assert.equal(body.total_queries, 3);
+  assert.equal(body.hit_rate, 1 / 3);
+  assert.equal(body.total_views, 1);
+  assert.equal(body.total_items, 2);
+  assert.equal(body.feedback_coverage, 1);
+  assert.equal(body.never_accessed_pct, 0.5);
+  assert.equal(body.north_star_count, 0);
+  assert.equal(body.north_star_pct, 0);
+  assert.deepEqual(body.top_0hit_keywords, [
+    {
+      normalized_key: "refund",
+      example_text: "Refund",
+      query_count: 2,
+    },
+  ]);
+  assert.deepEqual(body.never_accessed, [
+    {
+      id: "team-item-b",
+      claim: "Cache invalidation requires explicit owner handoff.",
+    },
+  ]);
+});
+
+test("reuse report applies min_age_days only to never_accessed", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "old-never-accessed",
+    claim: "Old untouched item.",
+    createdAt: daysAgo(10),
+  });
+  insertKnowledgeRow(db, {
+    id: "new-never-accessed",
+    claim: "New untouched item.",
+    createdAt: daysAgo(1),
+  });
+
+  const response = await app.request(
+    "http://localhost/api/reports/reuse?min_age_days=7",
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as ReuseReportResponse;
+
+  assert.equal(body.total_items, 2);
+  assert.equal(body.never_accessed_pct, 0.5);
+  assert.deepEqual(body.never_accessed, [
+    { id: "old-never-accessed", claim: "Old untouched item." },
+  ]);
 });


### PR DESCRIPTION
## Summary
- add `?since=`, `?project=`, and `?min_age_days=` support to `/api/reports/reuse`
- add `feedback_coverage`, `top_0hit_keywords`, and filtered `never_accessed` calculations
- extend backend tests for time windows, project scoping, pair coverage, and normalized 0-hit aggregation

## Verification
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" npm run test --workspace=packages/backend`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" npm run build --workspace=packages/backend`

Refs #41