### PR TITLE
feat(backend): add A1 task session schema

### DIFF
--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -42,6 +42,7 @@ function createUsageEventsTable(db: Database.Database): void {
       owner         TEXT NOT NULL,
       event_type    TEXT NOT NULL CHECK (event_type IN ('query', 'exposure', 'view')),
       request_id    TEXT,
+      task_id       TEXT REFERENCES tasks(task_id) ON DELETE SET NULL,
       query_text    TEXT,
       result_count  INTEGER,
       project       TEXT NOT NULL DEFAULT '',
@@ -103,7 +104,7 @@ function ensureUsageEventsSchema(db: Database.Database): void {
 
   db.exec(`
     INSERT INTO usage_events (
-      id, knowledge_id, owner, event_type, request_id,
+      id, knowledge_id, owner, event_type, request_id, task_id,
       query_text, result_count, project, search_mode, query_context, created_at
     )
     SELECT
@@ -112,6 +113,7 @@ function ensureUsageEventsSchema(db: Database.Database): void {
       legacy.owner,
       legacy.event_type,
       legacy.request_id,
+      NULL,
       NULL,
       NULL,
       COALESCE(knowledge.project, ''),
@@ -189,24 +191,52 @@ export function getDb(): Database.Database {
     CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(owner);
     CREATE INDEX IF NOT EXISTS idx_api_keys_revoked_at ON api_keys(revoked_at);
 
+    CREATE TABLE IF NOT EXISTS tasks (
+      task_id      TEXT PRIMARY KEY,
+      owner        TEXT NOT NULL,
+      project      TEXT,
+      description  TEXT NOT NULL,
+      status       TEXT NOT NULL CHECK (status IN ('open', 'completed', 'abandoned')) DEFAULT 'open',
+      opened_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      closed_at    TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_tasks_owner_status ON tasks(owner, status);
+    CREATE INDEX IF NOT EXISTS idx_tasks_project_status ON tasks(project, status);
+    CREATE INDEX IF NOT EXISTS idx_tasks_opened_at ON tasks(opened_at);
+
     CREATE TABLE IF NOT EXISTS reuse_feedback (
       id            INTEGER PRIMARY KEY AUTOINCREMENT,
       knowledge_id  TEXT NOT NULL REFERENCES knowledge(id) ON DELETE CASCADE,
       owner         TEXT NOT NULL,
       verdict       TEXT NOT NULL CHECK (verdict IN ('useful', 'not_useful', 'outdated')),
       comment       TEXT,
+      task_id       TEXT REFERENCES tasks(task_id) ON DELETE SET NULL,
       created_at    TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
     CREATE INDEX IF NOT EXISTS idx_reuse_feedback_knowledge ON reuse_feedback(knowledge_id);
     CREATE INDEX IF NOT EXISTS idx_reuse_feedback_owner ON reuse_feedback(owner);
     CREATE INDEX IF NOT EXISTS idx_reuse_feedback_created ON reuse_feedback(created_at);
+
+    CREATE TABLE IF NOT EXISTS task_publications (
+      task_id       TEXT NOT NULL REFERENCES tasks(task_id) ON DELETE CASCADE,
+      knowledge_id  TEXT NOT NULL REFERENCES knowledge(id) ON DELETE CASCADE,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (task_id, knowledge_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_task_publications_knowledge_id ON task_publications(knowledge_id);
   `);
 
   ensureUsageEventsSchema(_db);
+  ensureColumn(_db, "usage_events", "task_id", "TEXT REFERENCES tasks(task_id) ON DELETE SET NULL");
+  _db.exec("CREATE INDEX IF NOT EXISTS idx_usage_events_task_id ON usage_events(task_id)");
   ensureColumn(_db, "knowledge", "duplicate_of", "TEXT");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_knowledge_duplicate_of ON knowledge(duplicate_of)");
   ensureColumn(_db, "knowledge", "embedding", "BLOB");
+  ensureColumn(_db, "reuse_feedback", "task_id", "TEXT REFERENCES tasks(task_id) ON DELETE SET NULL");
+  _db.exec("CREATE INDEX IF NOT EXISTS idx_reuse_feedback_task_id ON reuse_feedback(task_id)");
   cleanupFalsePositiveDuplicateOf(_db);
 
   return _db;

--- a/packages/backend/tests/task-sessions-schema.test.ts
+++ b/packages/backend/tests/task-sessions-schema.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync, unlinkSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import Database from "better-sqlite3";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-task-sessions-schema-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+
+interface TableColumnInfo {
+  name: string;
+}
+
+interface UsageEventRow {
+  id: number;
+  knowledge_id: string | null;
+  owner: string;
+  event_type: string;
+  request_id: string | null;
+  task_id: string | null;
+  query_text: string | null;
+  result_count: number | null;
+  project: string;
+  search_mode: string | null;
+  query_context: string | null;
+  created_at: string;
+}
+
+interface ReuseFeedbackRow {
+  id: number;
+  knowledge_id: string;
+  owner: string;
+  verdict: string;
+  comment: string | null;
+  task_id: string | null;
+  created_at: string;
+}
+
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+function tableColumns(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as TableColumnInfo[]).map((column) => column.name);
+}
+
+function indexExists(db: Database.Database, name: string): boolean {
+  const row = db.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+  ).get(name);
+  return Boolean(row);
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+  const row = db.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(name);
+  return Boolean(row);
+}
+
+function resetDbFile(): void {
+  closeDb();
+  if (existsSync(dbPath)) {
+    unlinkSync(dbPath);
+  }
+}
+
+before(async () => {
+  const dbModule = await import("../src/db.ts");
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+});
+
+afterEach(() => {
+  resetDbFile();
+});
+
+after(() => {
+  resetDbFile();
+  rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.TEAM_MEMORY_DB;
+});
+
+test("fresh database creates task-session tables and trace-linkage columns", () => {
+  const db = getDb();
+
+  assert.ok(tableExists(db, "tasks"));
+  assert.ok(tableExists(db, "task_publications"));
+
+  assert.ok(tableColumns(db, "usage_events").includes("task_id"));
+  assert.ok(tableColumns(db, "reuse_feedback").includes("task_id"));
+
+  assert.ok(indexExists(db, "idx_usage_events_task_id"));
+  assert.ok(indexExists(db, "idx_reuse_feedback_task_id"));
+  assert.ok(indexExists(db, "idx_task_publications_knowledge_id"));
+});
+
+test("migrates legacy usage and feedback tables without losing rows", () => {
+  const legacyDb = new Database(dbPath);
+  legacyDb.pragma("foreign_keys = ON");
+
+  legacyDb.exec(`
+    CREATE TABLE knowledge (
+      id              TEXT PRIMARY KEY,
+      claim           TEXT NOT NULL,
+      detail          TEXT,
+      source          TEXT NOT NULL DEFAULT '[]',
+      project         TEXT NOT NULL,
+      module          TEXT,
+      tags            TEXT NOT NULL DEFAULT '[]',
+      confidence      TEXT NOT NULL CHECK (confidence IN ('high', 'medium', 'low')),
+      staleness_hint  TEXT NOT NULL,
+      owner           TEXT NOT NULL,
+      related_to      TEXT NOT NULL DEFAULT '[]',
+      supersedes      TEXT,
+      superseded_by   TEXT,
+      created_at      TEXT NOT NULL,
+      updated_at      TEXT NOT NULL
+    );
+
+    CREATE TABLE usage_events (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      knowledge_id  TEXT REFERENCES knowledge(id) ON DELETE CASCADE,
+      owner         TEXT NOT NULL,
+      event_type    TEXT NOT NULL CHECK (event_type IN ('query', 'exposure', 'view')),
+      request_id    TEXT,
+      query_text    TEXT,
+      result_count  INTEGER,
+      project       TEXT NOT NULL DEFAULT '',
+      search_mode   TEXT CHECK (search_mode IN ('fts', 'semantic', 'hybrid')),
+      query_context TEXT,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE reuse_feedback (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      knowledge_id  TEXT NOT NULL REFERENCES knowledge(id) ON DELETE CASCADE,
+      owner         TEXT NOT NULL,
+      verdict       TEXT NOT NULL CHECK (verdict IN ('useful', 'not_useful', 'outdated')),
+      comment       TEXT,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  legacyDb.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "legacy-item",
+    "Legacy usage rows should survive task-session migration.",
+    null,
+    JSON.stringify(["tests/task-sessions-schema.test.ts"]),
+    "team-memory",
+    null,
+    JSON.stringify(["migration"]),
+    "high",
+    "Recheck if schema semantics change.",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    null,
+    "2026-04-17T00:00:00.000Z",
+    "2026-04-17T00:00:00.000Z",
+  );
+
+  legacyDb.prepare(
+    `INSERT INTO usage_events (
+      knowledge_id, owner, event_type, request_id, query_text,
+      result_count, project, search_mode, query_context, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "legacy-item",
+    "LegacyUser",
+    "exposure",
+    "legacy-request",
+    null,
+    null,
+    "team-memory",
+    "hybrid",
+    "legacy query context",
+    "2026-04-17T00:00:00.000Z",
+  );
+
+  legacyDb.prepare(
+    `INSERT INTO reuse_feedback (
+      knowledge_id, owner, verdict, comment, created_at
+    ) VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    "legacy-item",
+    "LegacyUser",
+    "useful",
+    "Still relevant after migration.",
+    "2026-04-17T00:00:00.000Z",
+  );
+
+  legacyDb.close();
+
+  const db = getDb();
+
+  assert.ok(tableExists(db, "tasks"));
+  assert.ok(tableExists(db, "task_publications"));
+  assert.ok(tableColumns(db, "usage_events").includes("task_id"));
+  assert.ok(tableColumns(db, "reuse_feedback").includes("task_id"));
+
+  const usageRows = db.prepare(
+    `SELECT id, knowledge_id, owner, event_type, request_id, task_id, query_text,
+            result_count, project, search_mode, query_context, created_at
+     FROM usage_events
+     ORDER BY id ASC`,
+  ).all() as UsageEventRow[];
+
+  assert.equal(usageRows.length, 1);
+  assert.equal(usageRows[0]!.knowledge_id, "legacy-item");
+  assert.equal(usageRows[0]!.owner, "LegacyUser");
+  assert.equal(usageRows[0]!.event_type, "exposure");
+  assert.equal(usageRows[0]!.request_id, "legacy-request");
+  assert.equal(usageRows[0]!.task_id, null);
+  assert.equal(usageRows[0]!.project, "team-memory");
+  assert.equal(usageRows[0]!.search_mode, "hybrid");
+  assert.equal(usageRows[0]!.query_context, "legacy query context");
+
+  const feedbackRows = db.prepare(
+    `SELECT id, knowledge_id, owner, verdict, comment, task_id, created_at
+     FROM reuse_feedback
+     ORDER BY id ASC`,
+  ).all() as ReuseFeedbackRow[];
+
+  assert.equal(feedbackRows.length, 1);
+  assert.equal(feedbackRows[0]!.knowledge_id, "legacy-item");
+  assert.equal(feedbackRows[0]!.owner, "LegacyUser");
+  assert.equal(feedbackRows[0]!.verdict, "useful");
+  assert.equal(feedbackRows[0]!.comment, "Still relevant after migration.");
+  assert.equal(feedbackRows[0]!.task_id, null);
+});


### PR DESCRIPTION
## Summary
- add `tasks` and `task_publications` tables for A1 session/provenance linkage
- add nullable `task_id` trace-linkage columns to `usage_events` and `reuse_feedback`
- add schema tests covering fresh DB creation and legacy migration without data loss

## Scope
This is PR-1 of A1 only: schema + migration + tests. It does **not** add `/api/tasks/start`, `/api/tasks/:task_id/end`, or MCP-layer changes yet.

## Validation
- `node --test --import tsx packages/backend/tests/task-sessions-schema.test.ts`
- `npm run test --workspace=packages/backend`
- `npm run build --workspace=packages/backend`

Closes #42