### PR TITLE
fix(backend): sanitize FTS-sensitive task descriptions

### DIFF
--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -222,6 +222,17 @@ async function runSemanticCandidates(
     .slice(0, input.candidateLimit);
 }
 
+const FTS_RESERVED_KEYWORDS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+function buildFtsMatchQuery(rawQuery: string): string | null {
+  const tokens = rawQuery
+    .match(/[\p{L}\p{N}_]+/gu)
+    ?.filter((token) => !FTS_RESERVED_KEYWORDS.has(token.toUpperCase()));
+
+  if (!tokens || tokens.length === 0) return null;
+  return tokens.map((token) => `"${token.replaceAll("\"", "\"\"")}"`).join(" ");
+}
+
 async function runHybridSearch(
   db: ReturnType<typeof getDb>,
   input: {
@@ -251,7 +262,16 @@ async function runHybridSearch(
   }
   const whereClause = conditions.length > 0 ? `AND ${conditions.join(" AND ")}` : "";
   const sql = `SELECT k.*, rank FROM knowledge_fts fts JOIN knowledge k ON k.rowid = fts.rowid WHERE knowledge_fts MATCH ? ${whereClause} ORDER BY rank LIMIT ?`;
-  const ftsRows = db.prepare(sql).all(input.query, ...params, candidateLimit) as FtsSearchRow[];
+  const ftsMatchQuery = buildFtsMatchQuery(input.query);
+  let ftsRows: FtsSearchRow[] = [];
+  if (ftsMatchQuery) {
+    try {
+      ftsRows = db.prepare(sql).all(ftsMatchQuery, ...params, candidateLimit) as FtsSearchRow[];
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[runHybridSearch] FTS MATCH failed for ${JSON.stringify(input.query)}: ${message}`);
+    }
+  }
   const filteredFtsRows = ftsRows.filter((row) => matchesRequestedTags(row, input.tags));
   const ftsScores = normalizedFtsScores(filteredFtsRows);
 
@@ -589,7 +609,11 @@ api.post("/tasks/start", async (c) => {
     max_matches?: unknown;
   };
 
-  if (body.description === undefined || body.description === null || body.description === "") {
+  if (
+    body.description === undefined
+    || body.description === null
+    || (typeof body.description === "string" && body.description.trim() === "")
+  ) {
     return jsonTaskError(c, 400, "description is required", "task_description_required");
   }
   if (typeof body.description !== "string") {

--- a/packages/backend/tests/hybrid-search.test.ts
+++ b/packages/backend/tests/hybrid-search.test.ts
@@ -181,3 +181,25 @@ test("hybrid search falls back to pure FTS when query embeddings are unavailable
 
   process.env.EMBEDDING_API_KEY = "test-hybrid-key";
 });
+
+test("hybrid search treats FTS-sensitive user text as plain terms instead of MATCH syntax", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "auth-refactor-row",
+    claim: "Refactor auth middleware login flow",
+    embedding: null,
+  });
+
+  delete process.env.EMBEDDING_API_KEY;
+
+  const response = await app.request("http://localhost/api/knowledge/search?q=refactor%20auth-middleware%20OR%20login");
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { items: HybridSummary[]; total: number };
+
+  assert.equal(body.total, 1);
+  assert.deepEqual(body.items.map((item) => item.id), ["auth-refactor-row"]);
+  assert.equal(body.items[0]?.search_mode, "fts");
+
+  process.env.EMBEDDING_API_KEY = "test-hybrid-key";
+});

--- a/packages/backend/tests/task-sessions-routes.test.ts
+++ b/packages/backend/tests/task-sessions-routes.test.ts
@@ -248,6 +248,81 @@ test("start_task returns task_id for 0-hit sessions and still records a query ro
   assert.equal(events[0]!.project, "ghost-project");
 });
 
+test("start_task treats FTS-sensitive description text as plain user input instead of crashing", async () => {
+  const db = getDb();
+  const apiKey = createApiKey("Alice");
+  const descriptions = [
+    "unrelated-gibberish",
+    "fix #42: tokenize",
+    "user-input AND dangerous",
+    "refactor auth-middleware OR login",
+    "NEAR edge case",
+    "quote \"me\" please",
+    "测试中文描述",
+  ];
+
+  for (const description of descriptions) {
+    const response = await app.request("http://localhost/api/tasks/start", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        description,
+        project: "ghost-project",
+      }),
+    });
+
+    assert.equal(response.status, 201, `expected 201 for ${description}`);
+    const body = await response.json() as {
+      task_id: string;
+      description: string;
+      matches: unknown[];
+    };
+
+    assert.equal(body.description, description);
+    assert.ok(body.task_id);
+    assert.deepEqual(body.matches, []);
+  }
+
+  const queryRows = db.prepare(
+    `SELECT event_type, query_text, result_count
+     FROM usage_events
+     WHERE event_type = 'query'
+     ORDER BY id ASC`,
+  ).all() as Array<{
+    event_type: string;
+    query_text: string | null;
+    result_count: number | null;
+  }>;
+
+  assert.equal(queryRows.length, descriptions.length);
+  assert.deepEqual(queryRows.map((row) => row.query_text), descriptions);
+  assert.ok(queryRows.every((row) => row.result_count === 0));
+});
+
+test("start_task rejects blank-or-whitespace-only descriptions as required-field violations", async () => {
+  const apiKey = createApiKey("Alice");
+
+  for (const description of ["", "   ", "\t\n"]) {
+    const response = await app.request("http://localhost/api/tasks/start", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ description }),
+    });
+
+    assert.equal(response.status, 400, `expected 400 for ${JSON.stringify(description)}`);
+    assert.deepEqual(await response.json(), {
+      error: "description is required",
+      code: "task_description_required",
+    });
+  }
+});
+
 test("existing endpoints hard-reject unknown or foreign task_id but accept closed tasks for follow-up linkage", async () => {
   const db = getDb();
   insertKnowledgeRow(db, { id: "item-a", claim: "Control-plane billing note." });


### PR DESCRIPTION
## Summary
- sanitize human description/query text before passing it into `knowledge_fts MATCH`
- add a defensive FTS fallback that logs and returns zero FTS candidates instead of 500ing the route
- reject whitespace-only `start_task.description` values with the existing `task_description_required` contract
- add realistic-input regression coverage for both `start_task` and the shared `/api/knowledge/search` helper

## Root cause
`runHybridSearch()` was passing raw user text into FTS5 `MATCH`, so operator-like input such as `-`, `:`, `AND`, `OR`, `NOT`, and `NEAR` was parsed as FTS syntax rather than plain user text.

That violated the A1 contract that 0-hit task descriptions still return `201 + task_id + matches: []`.

## Fix
- build an FTS-safe implicit-AND query from user text by:
  - extracting plain text tokens
  - dropping reserved FTS keywords used as operators
  - quoting each token as a literal phrase term
- keep the raw user description for semantic search / task persistence / observability
- add a warning-backed defensive fallback if SQLite still rejects the FTS clause
- trim-check whitespace-only descriptions so `"   "` matches the existing `task_description_required` semantics

## Regression coverage
### `start_task`
These now all assert `201 + task_id + matches: []` when no rows match:
- `unrelated-gibberish`
- `fix #42: tokenize`
- `user-input AND dangerous`
- `refactor auth-middleware OR login`
- `NEAR edge case`
- `quote "me" please`
- `测试中文描述`

Whitespace-only inputs now assert `400 task_description_required` for:
- `""`
- `"   "`
- `"\t\n"`

### shared search helper
- `/api/knowledge/search?q=refactor auth-middleware OR login` now returns `200` and preserves useful FTS recall instead of 500ing

## Validation
- `node --test --import tsx packages/backend/tests/task-sessions-routes.test.ts`
- `node --test --import tsx packages/backend/tests/hybrid-search.test.ts`
- `npm run build --workspace=packages/backend`
- `npm run test --workspace=packages/backend`
