### PR TITLE
docs: M-docs batch for A1 task sessions + reuse tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,17 @@ Instead of every agent keeping private notes and repeating the same repo analysi
 
 ## What This Repo Contains
 
-Phase 1 ships four pieces:
-
 ```text
 Agent / CLI
     |
     v
-packages/mcp-server      MCP tools for agents
+packages/mcp-server      MCP tools for agents (publish / query / semantic / reuse_feedback / start_task / end_task / ...)
     |
     v
-packages/backend         REST API + SQLite + FTS5 knowledge store
+packages/backend         REST API + SQLite + FTS5 + provider-agnostic semantic search
+                         task sessions, reuse tracking, append-only supersede model
     |
-    +--> packages/dashboard   Read-only web UI for humans
+    +--> packages/dashboard   Read-only web UI for humans, including a Reuse tab
     |
     +--> e2e/scripts          Validation scripts for the main reuse flow
 ```
@@ -33,10 +32,11 @@ packages/backend         REST API + SQLite + FTS5 knowledge store
 
 | Path | Purpose |
 | --- | --- |
-| `packages/backend` | Hono API server, SQLite storage, FTS5 search, append-only supersede model |
-| `packages/mcp-server` | 5 MCP tools that proxy agent calls to the backend |
-| `packages/dashboard` | Read-only dashboard for browsing, filtering, and inspecting knowledge items |
-| `e2e/scripts` | Demo and smoke scripts that validate publish -> query -> get flows |
+| `packages/backend` | Hono API server, SQLite storage, FTS5 + vector-hybrid search, task sessions, reuse tracking, append-only supersede model, admin key CLI |
+| `packages/mcp-server` | MCP tools that proxy agent calls to the backend (see [MCP Tools](#mcp-tools) below) |
+| `packages/dashboard` | Read-only dashboard for browsing, filtering, and inspecting knowledge items; includes a Reuse tab for team reuse metrics |
+| `e2e/scripts` | Demo and smoke scripts that validate publish -> query -> get -> feedback flows |
+| `docs/` | Agent behavior protocol, MCP config template, API reference (`docs/api.md`) |
 | `CONTRIBUTING.md` | GitHub workflow, branch naming, review expectations |
 
 ## Core Concept: Knowledge Items
@@ -58,31 +58,47 @@ Important behavior:
 - Core facts are append-only.
 - If a fact changes, publish a new item and point `supersedes` at the old one.
 - Search/list hide superseded entries by default.
-- Agents are expected to `query_knowledge` before work and `publish_knowledge` after work.
+- Agents are expected to query the team's memory before starting work (via `start_task` or `query_knowledge` / `semantic_search`) and publish any reusable finding after it (via `end_task({ findings })` or `publish_knowledge`).
+- Reading and writing are both measurable: `view` and `reuse_feedback` records feed the reuse report.
 
 ## MCP Tools
 
-The MCP bridge exposes five tools:
+The MCP bridge exposes nine tools, grouped by purpose:
 
-1. `publish_knowledge`
-2. `query_knowledge`
-3. `list_knowledge`
-4. `get_knowledge`
-5. `update_knowledge`
+**Knowledge reads**
 
-`update_knowledge` is metadata-only. If the actual claim changes, publish a new item instead of mutating history.
+1. `query_knowledge` — FTS5 keyword search
+2. `semantic_search` — embedding-based similarity search
+3. `list_knowledge` — browse by project / owner / tag
+4. `get_knowledge` — open a specific item (emits a `view` event; accepts optional `query_context` and `task_id`)
+
+**Knowledge writes**
+
+5. `publish_knowledge` — publish a structured claim (supports `supersedes` for facts that change)
+6. `update_knowledge` — metadata-only update (tags, confidence, staleness_hint, related_to). If a claim's meaning changes, publish a new item and point `supersedes` at the old one — do not mutate history.
+
+**Reuse signal**
+
+7. `reuse_feedback` — after opening an item, tell the system whether it was `useful`, `not_useful`, or `outdated`. This is the strong reuse signal that reports prioritize over raw views.
+
+**Task sessions** (framework-neutral measurement primitive)
+
+8. `start_task` — open a task session, run a hybrid search on the description, return `task_id` + matches. Even 0-hit sessions return a `task_id`.
+9. `end_task` — close a task session; optionally accepts `findings[]` and publishes each as a knowledge item linked to the task via `task_publications`.
+
+Once a task is open, agents can pass its `task_id` to any knowledge-read or feedback call to tie that interaction to the session. `completed` / `abandoned` task ids remain valid linkage targets for follow-up reads.
 
 ## REST API
 
-The backend exposes five endpoints under `/api`:
+The backend exposes the surface under `/api`:
 
-- `POST /api/knowledge`
-- `GET /api/knowledge/search?q=...`
-- `GET /api/knowledge`
-- `GET /api/knowledge/:id`
-- `PATCH /api/knowledge/:id`
+- Knowledge: `POST /api/knowledge`, `GET /api/knowledge`, `GET /api/knowledge/:id`, `PATCH /api/knowledge/:id`, `GET /api/knowledge/search`, `GET /api/knowledge/semantic-search`
+- Reuse feedback: `POST /api/knowledge/:id/feedback`
+- Task sessions: `POST /api/tasks/start`, `POST /api/tasks/:task_id/end`
+- Reports: `GET /api/reports/reuse`
+- Health: `GET /health`
 
-The model is intentionally small: publish, browse/search, inspect, and update metadata.
+See [`docs/api.md`](docs/api.md) for the full request/response reference, query parameters, error codes, and the `task_id?` passthrough semantics.
 
 ## Quick Start
 
@@ -192,14 +208,16 @@ curl "http://localhost:3460/api/knowledge/search?q=deploy&project=infer-monorepo
 
 ### For agents
 
-Recommended workflow:
+Recommended workflow (see [`docs/agent-protocol.md`](docs/agent-protocol.md) for the canonical version):
 
-1. Before starting work, call `query_knowledge` or `list_knowledge`.
-2. Read the best match with `get_knowledge`.
-3. Reuse that context in the new task instead of redoing the same analysis.
-4. After finishing, `publish_knowledge` for any reusable finding.
+1. Before starting a task, call `start_task({ description, project })`. The response carries a `task_id` plus the best existing matches for your task.
+2. If a match looks relevant, open it with `get_knowledge({ id, task_id, query_context })`.
+3. After you know whether the item helped, call `reuse_feedback({ knowledge_id, verdict, task_id })` — `useful` / `not_useful` / `outdated`.
+4. When done, call `end_task({ task_id, status, findings? })`. Any reusable conclusions you pass in `findings[]` get published as knowledge items linked to this task via `task_publications`.
 
-The MVP success condition for this project is simple: Agent B should query Agent A's published knowledge and skip one round of repeated research.
+`start_task` / `end_task` are a framework-neutral **measurement primitive**, not a workflow engine — they exist so reports can count "how often did querying the team's memory before work actually save a round of re-analysis?". Agents that don't open sessions still use `query_knowledge` / `semantic_search` / `get_knowledge` / `publish_knowledge` / `reuse_feedback` directly.
+
+The success condition for this project is simple: Agent B should query Agent A's published knowledge and skip one round of repeated research — and the team should be able to see that happen in the Reuse tab.
 
 ### For humans
 
@@ -215,27 +233,31 @@ This is intentionally read-only in Phase 1.
 
 The repo includes scripts for validating the main flow:
 
-- HTTP path: publish -> search -> get
-- MCP path: `publish_knowledge` -> `query_knowledge` -> `get_knowledge`
+- HTTP path: publish → search → get → feedback
+- MCP path: `publish_knowledge` → `query_knowledge` → `get_knowledge` → `reuse_feedback`
+- Reuse loop: `e2e/scripts/reuse-loop.ts` exercises the end-to-end `start_task` → `get_knowledge` → `reuse_feedback` → `end_task` sequence and asserts the report surface
 
 See `e2e/scripts/` for the current demo and smoke scripts.
 
-## Current Phase 1 Status
+## Current Status
 
 Implemented:
 
 - backend knowledge store + REST API
-- MCP bridge with 5 tools
-- read-only dashboard
-- E2E validation scripts
+- MCP bridge (9 tools)
+- read-only dashboard with Reuse tab
+- E2E validation scripts (publish / query / view / feedback / task-session loops)
+- API-key authentication and key-management CLI
+- Hybrid search: FTS5 + provider-agnostic semantic embeddings (`EMBEDDING_API_KEY` / `EMBEDDING_API_BASE` / `EMBEDDING_MODEL`)
+- Duplicate detection at publish time (configurable thresholds)
+- Reuse tracking: `query` / `exposure` / `view` events plus first-class `reuse_feedback`; reuse report at `GET /api/reports/reuse`
+- Task sessions: `start_task` / `end_task` primitive, `task_id?` passthrough on reads + feedback, `task_publications` provenance
 
 Still intentionally limited:
 
-- no auth or RBAC
-- no vector search
 - no subscription/notification layer
-- no workflow engine or task management
-- no repo-root dev orchestration yet
+- no workflow engine — task sessions are a measurement primitive, not an orchestration runtime
+- no repo-root dev orchestration beyond the quick-start scripts
 
 ## Collaboration Workflow
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -107,11 +107,12 @@ The response body includes a `warnings[]` array when the publish encounters a po
 | 400 | `{ "error": "tags must be a non-empty array of strings" }` | `tags` empty/invalid |
 | 400 | `{ "error": "confidence must be one of: high, medium, low" }` | Invalid confidence |
 | 400 | `{ "error": "Related item not found: …" }` | `related_to` contains unknown id |
-| 401 | — | Missing/invalid Authorization |
+| 401 | `{ "error": "…", "code": "auth_missing" }` | Authorization header omitted |
+| 401 | `{ "error": "…", "code": "auth_invalid" }` | Authorization header present but token does not match an active API key |
 
 ### `GET /api/knowledge`
 
-List knowledge items. Optional auth (read tracking).
+List knowledge items. No auth (unauthenticated listing; does not record `usage_events`).
 
 **Query parameters**
 
@@ -119,9 +120,9 @@ List knowledge items. Optional auth (read tracking).
 |---|---|
 | `project` | Filter by project |
 | `owner` | Filter by owner |
-| `tags` | Comma-separated; items must carry all listed tags |
+| `tags` | Comma-separated; items match if they carry **any** of the listed tags (OR semantics) |
 | `include_superseded` | `true` to include superseded entries (default `false`) |
-| `limit` | Integer, defaults to 50 |
+| `limit` | Integer, defaults to 50 (capped at 200) |
 | `offset` | Integer, defaults to 0 |
 
 **Response — 200**
@@ -150,7 +151,8 @@ When auth is provided, a `usage_events` row with `event_type='view'` is written.
 | Status | Code | Condition |
 |---|---|---|
 | 404 | — | Knowledge id not found |
-| 401 | `auth_missing` | `task_id` provided without Authorization |
+| 401 | `auth_missing` | `task_id` provided without Authorization header |
+| 401 | `auth_invalid` | `task_id` provided with an Authorization header whose token does not match an active API key |
 | 404 | `task_not_found` | `task_id` does not exist |
 | 403 | `task_owner_forbidden` | `task_id` owned by a different user |
 
@@ -162,7 +164,7 @@ Only the following fields are mutable: `tags`, `confidence`, `staleness_hint`, `
 
 **Response — 200** — updated knowledge row.
 
-**Errors** — `400` for invalid field values; `401` on missing auth; `404` if the id does not exist.
+**Errors** — `400` for invalid field values; `401` `auth_missing` / `auth_invalid` as described above; `404` if the id does not exist.
 
 ---
 
@@ -181,9 +183,9 @@ User text is sanitized before it reaches the FTS5 `MATCH` clause: tokens are ext
 | `q` | **Required.** Search text. |
 | `project` | Filter by project |
 | `module` | Filter by module |
-| `tags` | Comma-separated; items must carry all listed tags |
+| `tags` | Comma-separated; items match if they carry **any** of the listed tags (OR semantics) |
 | `include_superseded` | `true` to include superseded entries |
-| `limit` | Integer |
+| `limit` | Integer, defaults to 20 (capped at 100) |
 | `task_id` | Optional task session linkage |
 
 **Response — 200**
@@ -201,26 +203,27 @@ When authenticated, each returned item is recorded as an `exposure` event sharin
 
 ### `GET /api/knowledge/semantic-search`
 
-Embedding-based similarity search. Optional auth; optional `task_id` passthrough. Falls back to pure FTS if embedding generation fails.
+Embedding-based similarity search. Optional auth (read tracking); optional `task_id` passthrough. If query-embedding generation fails, the endpoint still returns `200` with an empty `items` array (observability rows still record the failure when authenticated).
 
 **Query parameters**
 
 | Param | Meaning |
 |---|---|
-| `query` | **Required.** Natural-language query. |
-| `project`, `module`, `tags`, `include_superseded`, `limit`, `task_id` | Same semantics as `/knowledge/search` |
+| `q` | **Required.** Natural-language query. |
+| `project` | Filter by project |
+| `limit` | Integer, defaults to 10 (capped at 100) |
+| `task_id` | Optional task session linkage |
 
 **Response — 200**
 
 ```json
 {
-  "items": [ { …knowledge row…, "search_mode": "semantic" \| "hybrid", "score": 0.72 } ],
-  "total": 5,
-  "retrieval_mode": "hybrid"
+  "items": [ { …knowledge row…, "similarity": 0.72 } ],
+  "total": 5
 }
 ```
 
-`retrieval_mode` is one of `"fts"`, `"semantic"`, or `"hybrid"`.
+Each item is a knowledge-row summary with a `similarity` score (cosine against the query embedding). `total` is the count of rows that had embeddings and were considered (i.e. pre-`limit` eligible pool), not the count returned.
 
 ---
 
@@ -241,10 +244,12 @@ Record a verdict on a knowledge item. **Auth required.** Optional `task_id` link
 **Response — 201**
 
 ```json
-{ "id": "…", "knowledge_id": "…", "owner": "alice", "verdict": "useful", "comment": null, "task_id": null, "created_at": "…" }
+{ "knowledge_id": "…", "owner": "alice", "verdict": "useful", "comment": null, "created_at": "…" }
 ```
 
-**Errors** — `400` on invalid verdict; `401` on missing auth; `404` if knowledge id not found; task-trace auth errors as documented.
+`task_id` is persisted to the `reuse_feedback` row when provided in the request, but the response body does not echo it.
+
+**Errors** — `400` on invalid verdict; `401` `auth_missing` / `auth_invalid`; `404` if knowledge id not found; task-trace auth errors as documented.
 
 ---
 
@@ -273,12 +278,12 @@ The session is persisted with the **raw** description (before sanitization). Hyb
   "task_id": "…",
   "description": "…",
   "project": "…" | null,
-  "retrieval_mode": "fts" | "semantic" | "hybrid",
-  "matches": [ { …knowledge row…, "search_mode": "hybrid", "score": 0.81 } ]
+  "retrieval_mode": "fts" | "hybrid",
+  "matches": [ { …knowledge row…, "search_mode": "fts" | "hybrid", "score": 0.81 } ]
 }
 ```
 
-0-hit sessions still return `201` with `task_id` and `matches: []`. Failed-embedding queries still return `201`; the query row records the failure for reuse-report observability.
+Match rows mirror the shape returned by `GET /api/knowledge/search` — each row is a knowledge-row summary plus `search_mode` and `score`. 0-hit sessions still return `201` with `task_id` and `matches: []`. Failed-embedding queries still return `201` on the FTS path; the query row records the failure for reuse-report observability.
 
 **Errors**
 
@@ -288,7 +293,8 @@ The session is persisted with the **raw** description (before sanitization). Hyb
 | 400 | `task_description_invalid` | `description` is not a string |
 | 400 | `task_project_invalid` | `project` provided but not a string |
 | 400 | `task_max_matches_invalid` | `max_matches` not an integer in `[1, 100]` |
-| 401 | — | Missing/invalid Authorization |
+| 401 | `auth_missing` | Authorization header omitted |
+| 401 | `auth_invalid` | Authorization header present but the token does not match an active API key |
 
 ### `POST /api/tasks/:task_id/end`
 
@@ -298,7 +304,7 @@ Close a task session and optionally publish findings. **Auth required.** Only th
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `status` | `"completed" \| "abandoned"` | yes | Cannot close as `open`. |
+| `status` | `"completed" \| "abandoned"` | no | Defaults to `"completed"` when omitted. Cannot be `"open"`. |
 | `findings` | array of publish bodies | no | Each entry is a `POST /api/knowledge` body (minus `owner`, which is inferred). Published atomically per finding; linked to the task via `task_publications`. |
 
 Closure happens first (status + `closed_at` written). Then findings are published sequentially; the first failure short-circuits.
@@ -332,9 +338,10 @@ The task is left in the closed state regardless of publish outcome — retrying 
 
 | Status | Code | Condition |
 |---|---|---|
-| 400 | `task_status_invalid` | `status` missing or not `completed`/`abandoned` |
+| 400 | `task_status_invalid` | `status` provided but not `"completed"` or `"abandoned"` (omitted is legal — defaults to `"completed"`) |
 | 400 | `task_findings_invalid` | `findings` provided but not an array |
-| 401 | — | Missing/invalid Authorization |
+| 401 | `auth_missing` | Authorization header omitted |
+| 401 | `auth_invalid` | Authorization header present but the token does not match an active API key |
 | 403 | `task_owner_forbidden` | Caller is not the task owner |
 | 404 | `task_not_found` | `task_id` does not exist |
 | 409 | `task_already_closed` | Session is already `completed` or `abandoned` |
@@ -381,7 +388,8 @@ Task-session and task-trace endpoints return `{ error, code }` with a stable `co
 
 | Code | Status | Surface |
 |---|---|---|
-| `auth_missing` | 401 | Any endpoint with `task_id` passthrough if the caller omits auth |
+| `auth_missing` | 401 | Any auth-required endpoint (`PATCH /knowledge/:id`, `POST /knowledge/:id/feedback`, `POST /tasks/start`, `POST /tasks/:id/end`) or any optional-auth endpoint with `task_id` passthrough when the caller omits the Authorization header |
+| `auth_invalid` | 401 | Same surfaces — Authorization header present, but the bearer token does not match an active API key |
 | `task_description_required` | 400 | `POST /tasks/start` |
 | `task_description_invalid` | 400 | `POST /tasks/start` |
 | `task_project_invalid` | 400 | `POST /tasks/start` |

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,7 +72,20 @@ Publish a new knowledge item. **Auth required.**
 | `related_to` | string[] | no | Array of existing knowledge ids; invalid ids return `400`. |
 | `supersedes` | string | no | Existing knowledge id. Sets `superseded_by` on the referenced item. |
 
-The response body includes a `warnings[]` array when the publish encounters a possible-duplicate match (configurable via the duplicate-detection thresholds). Duplicates are surfaced as warnings, not errors — the item is still persisted.
+**Minimal valid request body**
+
+```json
+{
+  "claim": "FTS5 sanitizer tokenizes user input before MATCH",
+  "source": ["packages/backend/src/routes.ts"],
+  "project": "team-memory",
+  "tags": ["architecture", "search"],
+  "confidence": "high",
+  "staleness_hint": "Recheck if FTS5 syntax extensions change."
+}
+```
+
+Note that `source` and `tags` are **string arrays**, not strings — a common first-attempt mistake when seeding manually. The response body includes a `warnings[]` array when the publish encounters a possible-duplicate match (configurable via the duplicate-detection thresholds). Duplicates are surfaced as warnings, not errors — the item is still persisted.
 
 **Response — 201**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,410 @@
+# Team Memory REST API Reference
+
+This document is the canonical reference for the HTTP surface exposed by `packages/backend`. The MCP bridge in `packages/mcp-server` ultimately calls these endpoints — reading this doc is equivalent to reading the wire contract for every agent tool.
+
+For recommended agent workflows (when to publish, when to call `reuse_feedback`, when to open a task session), see [`agent-protocol.md`](agent-protocol.md).
+
+---
+
+## Base URL and conventions
+
+- All endpoints are mounted under `/api` (health is under `/health`, not `/api/health`).
+- Request and response bodies are JSON, UTF-8 encoded.
+- Timestamps are ISO-8601 strings (`2026-04-17T18:42:25.123Z`).
+- `id` values are UUIDv4 strings.
+- Unknown query parameters are ignored.
+- Error responses have the shape `{ "error": string }` for legacy endpoints and `{ "error": string, "code": string }` for the task-session and task-trace surfaces. The `code` is stable; `error` is human-readable and may be reworded.
+
+## Authentication
+
+The backend uses a simple Bearer token model. Tokens are minted with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner>`) and identify an owner plus optional default project.
+
+Three auth postures show up below:
+
+| Posture | Behavior |
+|---|---|
+| **Required** | Missing/invalid `Authorization` header returns `401`. The caller's owner is used for writes and event attribution. |
+| **Optional (read tracking)** | The endpoint serves requests without auth. Providing a valid `Authorization: Bearer <api_key>` header causes the read to be logged as a `view` / `exposure` / `query` event for reuse tracking. |
+| **Optional (passthrough)** | Same as "optional (read tracking)", but the endpoint additionally accepts a `task_id` (query or body). If `task_id` is provided, auth becomes effectively required: `401` on missing auth, `403` on foreign task owner, `404` on unknown task id. |
+
+The task-session endpoints (`/api/tasks/*`) always require auth.
+
+Header format:
+
+```
+Authorization: Bearer <api_key>
+```
+
+---
+
+## Health
+
+### `GET /health`
+
+Returns service liveness. No auth.
+
+**Response — 200**
+
+```json
+{ "status": "ok" }
+```
+
+---
+
+## Knowledge
+
+### `POST /api/knowledge`
+
+Publish a new knowledge item. **Auth required.**
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `claim` | string | yes | One falsifiable conclusion. |
+| `source` | string[] | yes | Non-empty array of citations (file paths, URLs, PR numbers). |
+| `project` | string | yes | Project namespace. |
+| `module` | string | no | Optional sub-module within the project. |
+| `tags` | string[] | yes | Non-empty array. |
+| `confidence` | `"high" \| "medium" \| "low"` | yes | |
+| `staleness_hint` | string | yes | Trigger condition for re-verification. |
+| `detail` | string | no | Longer body text. |
+| `related_to` | string[] | no | Array of existing knowledge ids; invalid ids return `400`. |
+| `supersedes` | string | no | Existing knowledge id. Sets `superseded_by` on the referenced item. |
+
+The response body includes a `warnings[]` array when the publish encounters a possible-duplicate match (configurable via the duplicate-detection thresholds). Duplicates are surfaced as warnings, not errors — the item is still persisted.
+
+**Response — 201**
+
+```json
+{
+  "id": "…",
+  "claim": "…",
+  "source": ["…"],
+  "project": "…",
+  "module": null,
+  "tags": ["…"],
+  "confidence": "high",
+  "staleness_hint": "…",
+  "detail": null,
+  "owner": "alice",
+  "related_to": [],
+  "supersedes": null,
+  "superseded_by": null,
+  "duplicate_of": null,
+  "created_at": "…",
+  "updated_at": "…",
+  "warnings": []
+}
+```
+
+**Errors**
+
+| Status | Error shape | Condition |
+|---|---|---|
+| 400 | `{ "error": "Missing required fields: …" }` | Required field missing or empty |
+| 400 | `{ "error": "source must be a non-empty array of strings" }` | `source` empty/invalid |
+| 400 | `{ "error": "tags must be a non-empty array of strings" }` | `tags` empty/invalid |
+| 400 | `{ "error": "confidence must be one of: high, medium, low" }` | Invalid confidence |
+| 400 | `{ "error": "Related item not found: …" }` | `related_to` contains unknown id |
+| 401 | — | Missing/invalid Authorization |
+
+### `GET /api/knowledge`
+
+List knowledge items. Optional auth (read tracking).
+
+**Query parameters**
+
+| Param | Meaning |
+|---|---|
+| `project` | Filter by project |
+| `owner` | Filter by owner |
+| `tags` | Comma-separated; items must carry all listed tags |
+| `include_superseded` | `true` to include superseded entries (default `false`) |
+| `limit` | Integer, defaults to 50 |
+| `offset` | Integer, defaults to 0 |
+
+**Response — 200**
+
+```json
+{ "items": [ { … knowledge row … } ], "total": 123 }
+```
+
+### `GET /api/knowledge/:id`
+
+Retrieve a single knowledge item. Optional auth (read tracking); optional `task_id` passthrough.
+
+**Query parameters**
+
+| Param | Meaning |
+|---|---|
+| `query_context` | Optional label attached to the resulting `view` event (recommended when the read follows a search) |
+| `task_id` | Optional task session id to link this view to |
+
+When auth is provided, a `usage_events` row with `event_type='view'` is written. When `task_id` is provided, auth is required (see [Authentication](#authentication)).
+
+**Response — 200** — knowledge row (same shape as the `POST` response, without `warnings`).
+
+**Errors**
+
+| Status | Code | Condition |
+|---|---|---|
+| 404 | — | Knowledge id not found |
+| 401 | `auth_missing` | `task_id` provided without Authorization |
+| 404 | `task_not_found` | `task_id` does not exist |
+| 403 | `task_owner_forbidden` | `task_id` owned by a different user |
+
+### `PATCH /api/knowledge/:id`
+
+Metadata-only update. **Auth required.**
+
+Only the following fields are mutable: `tags`, `confidence`, `staleness_hint`, `related_to`, `duplicate_of`. Claims are append-only — if a claim's meaning changes, publish a new item with `supersedes` set.
+
+**Response — 200** — updated knowledge row.
+
+**Errors** — `400` for invalid field values; `401` on missing auth; `404` if the id does not exist.
+
+---
+
+## Knowledge search
+
+### `GET /api/knowledge/search`
+
+FTS5 keyword search. Optional auth (read tracking); optional `task_id` passthrough.
+
+User text is sanitized before it reaches the FTS5 `MATCH` clause: tokens are extracted (`[\p{L}\p{N}_]+`), FTS reserved keywords (`AND` / `OR` / `NOT` / `NEAR`) are dropped, and each remaining token is quoted as a literal term. Descriptions containing hyphens, colons, boolean keywords, or unicode text therefore return results (or an empty array) rather than 500.
+
+**Query parameters**
+
+| Param | Meaning |
+|---|---|
+| `q` | **Required.** Search text. |
+| `project` | Filter by project |
+| `module` | Filter by module |
+| `tags` | Comma-separated; items must carry all listed tags |
+| `include_superseded` | `true` to include superseded entries |
+| `limit` | Integer |
+| `task_id` | Optional task session linkage |
+
+**Response — 200**
+
+```json
+{
+  "items": [ { …knowledge row…, "search_mode": "fts", "score": 0.87 } ],
+  "total": 5
+}
+```
+
+When authenticated, each returned item is recorded as an `exposure` event sharing a `request_id` with the parent `query` event.
+
+**Errors** — `400` when `q` is missing; passthrough auth errors as documented above.
+
+### `GET /api/knowledge/semantic-search`
+
+Embedding-based similarity search. Optional auth; optional `task_id` passthrough. Falls back to pure FTS if embedding generation fails.
+
+**Query parameters**
+
+| Param | Meaning |
+|---|---|
+| `query` | **Required.** Natural-language query. |
+| `project`, `module`, `tags`, `include_superseded`, `limit`, `task_id` | Same semantics as `/knowledge/search` |
+
+**Response — 200**
+
+```json
+{
+  "items": [ { …knowledge row…, "search_mode": "semantic" \| "hybrid", "score": 0.72 } ],
+  "total": 5,
+  "retrieval_mode": "hybrid"
+}
+```
+
+`retrieval_mode` is one of `"fts"`, `"semantic"`, or `"hybrid"`.
+
+---
+
+## Reuse feedback
+
+### `POST /api/knowledge/:id/feedback`
+
+Record a verdict on a knowledge item. **Auth required.** Optional `task_id` linkage.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `verdict` | `"useful" \| "not_useful" \| "outdated"` | yes | |
+| `comment` | string | no | Free-form note |
+| `task_id` | string | no | Task session linkage |
+
+**Response — 201**
+
+```json
+{ "id": "…", "knowledge_id": "…", "owner": "alice", "verdict": "useful", "comment": null, "task_id": null, "created_at": "…" }
+```
+
+**Errors** — `400` on invalid verdict; `401` on missing auth; `404` if knowledge id not found; task-trace auth errors as documented.
+
+---
+
+## Task sessions
+
+Task sessions are a framework-neutral measurement primitive. `start_task` opens a session and returns matches for the task description; `end_task` closes it and optionally publishes findings linked via `task_publications`. State is not a permission boundary — `completed` and `abandoned` sessions remain valid linkage targets for follow-up reads and feedback.
+
+### `POST /api/tasks/start`
+
+Open a task session. **Auth required.**
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `description` | string | yes | Non-empty after trim. Can contain arbitrary punctuation and operator-like words; FTS sanitization is internal. |
+| `project` | string | no | Scope hybrid search to a project |
+| `max_matches` | integer | no | Range `[1, 100]`, default `10` |
+
+The session is persisted with the **raw** description (before sanitization). Hybrid search runs with `search_mode: "hybrid"` and is recorded as a `query` event with `task_id` linked.
+
+**Response — 201**
+
+```json
+{
+  "task_id": "…",
+  "description": "…",
+  "project": "…" | null,
+  "retrieval_mode": "fts" | "semantic" | "hybrid",
+  "matches": [ { …knowledge row…, "search_mode": "hybrid", "score": 0.81 } ]
+}
+```
+
+0-hit sessions still return `201` with `task_id` and `matches: []`. Failed-embedding queries still return `201`; the query row records the failure for reuse-report observability.
+
+**Errors**
+
+| Status | Code | Condition |
+|---|---|---|
+| 400 | `task_description_required` | `description` missing, empty, or whitespace-only |
+| 400 | `task_description_invalid` | `description` is not a string |
+| 400 | `task_project_invalid` | `project` provided but not a string |
+| 400 | `task_max_matches_invalid` | `max_matches` not an integer in `[1, 100]` |
+| 401 | — | Missing/invalid Authorization |
+
+### `POST /api/tasks/:task_id/end`
+
+Close a task session and optionally publish findings. **Auth required.** Only the task's owner can close it, and only sessions currently in `open` state can be closed (re-closing returns `409`).
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `status` | `"completed" \| "abandoned"` | yes | Cannot close as `open`. |
+| `findings` | array of publish bodies | no | Each entry is a `POST /api/knowledge` body (minus `owner`, which is inferred). Published atomically per finding; linked to the task via `task_publications`. |
+
+Closure happens first (status + `closed_at` written). Then findings are published sequentially; the first failure short-circuits.
+
+**Response — 200 (success)**
+
+```json
+{ "task_id": "…", "status": "completed", "published_ids": ["…","…"], "duration_ms": 1234 }
+```
+
+**Response — 400 (partial publish failure)** — body carries `published_ids[]` for findings that succeeded before the failure, plus an `error` object identifying the failing index:
+
+```json
+{
+  "task_id": "…",
+  "status": "completed",
+  "published_ids": ["id-0"],
+  "duration_ms": 1234,
+  "error": {
+    "code": "task_publish_failed",
+    "failed_index": 1,
+    "publish_status": 400,
+    "publish_error": "Missing required fields: staleness_hint"
+  }
+}
+```
+
+The task is left in the closed state regardless of publish outcome — retrying `end_task` on a closed task returns `409`. To publish additional findings after close, use `POST /api/knowledge` directly (the session-external retry will not count toward `task_publications` provenance — this is intentional).
+
+**Errors**
+
+| Status | Code | Condition |
+|---|---|---|
+| 400 | `task_status_invalid` | `status` missing or not `completed`/`abandoned` |
+| 400 | `task_findings_invalid` | `findings` provided but not an array |
+| 401 | — | Missing/invalid Authorization |
+| 403 | `task_owner_forbidden` | Caller is not the task owner |
+| 404 | `task_not_found` | `task_id` does not exist |
+| 409 | `task_already_closed` | Session is already `completed` or `abandoned` |
+| 400 | `task_publish_failed` | See partial-failure body above |
+
+---
+
+## Reports
+
+### `GET /api/reports/reuse`
+
+Team-wide reuse snapshot. No auth.
+
+**Query parameters (M1b)**
+
+| Param | Meaning |
+|---|---|
+| `since=Nd` | Restrict the slice to events newer than `N` days (e.g. `7d`, `30d`). Filters `usage_events` and `reuse_feedback` rows; does **not** filter the knowledge baseline. Omit for lifetime. `400` if the format isn't `Nd`. |
+| `project=<name>` | Scope both knowledge baseline and event slice to one project |
+| `min_age_days=N` | Only filters the `never_accessed` **list** (hide items younger than `N` days). Does not affect `never_accessed_pct`, which always uses the unfiltered baseline. `400` if not a non-negative integer. |
+
+**Response — 200**
+
+| Field | Meaning |
+|---|---|
+| `total_queries` | Count of `query` rows in the slice. Includes 0-hit and failed-embedding queries. |
+| `hit_rate` | `queries_with_result / total_queries`. `0` when there are no queries. |
+| `total_views` | Count of `view` rows in the slice. |
+| `total_items` | Total knowledge rows (filtered by `project` if provided; not filtered by `since`). |
+| `never_accessed` | Items with no `exposure` / `view` / `feedback` **within the slice**. Slice-relative: an item whose events are all older than the cutoff still appears here. Further filtered by `min_age_days` if provided. |
+| `never_accessed_pct` | `baseNeverAccessed / total_items` — uses the **unfiltered** baseline (independent of `min_age_days`) so the percentage stays comparable across age thresholds. |
+| `feedback_coverage` | `(viewedPairs ∩ feedbackPairs) / viewedPairs.size` where each pair is `(owner, knowledge_id)`. Slice-relative. `0` when no views in slice. |
+| `top_0hit_keywords` | Top 10 0-hit search queries in the slice, each `{ normalized_key, example_text, query_count }`. Normalization: `trim + lowercase + collapse whitespace`. Sorted by `query_count` desc then `example_text` asc. |
+| `north_star_count` | Items used by ≥ 2 distinct owners via `view` or `useful` feedback (slice-relative). |
+| `north_star_pct` | `north_star_count / total_items`. |
+| `north_star` | **Deprecated** back-compat alias for `north_star_pct`. Will be removed. |
+| `top_reused` | Top 10 items by `view_count + useful_feedback_count`, per-owner uniqueness tiebreaker (slice-relative). |
+
+---
+
+## Error code catalog
+
+Task-session and task-trace endpoints return `{ error, code }` with a stable `code`. The full set:
+
+| Code | Status | Surface |
+|---|---|---|
+| `auth_missing` | 401 | Any endpoint with `task_id` passthrough if the caller omits auth |
+| `task_description_required` | 400 | `POST /tasks/start` |
+| `task_description_invalid` | 400 | `POST /tasks/start` |
+| `task_project_invalid` | 400 | `POST /tasks/start` |
+| `task_max_matches_invalid` | 400 | `POST /tasks/start` |
+| `task_status_invalid` | 400 | `POST /tasks/:id/end` |
+| `task_findings_invalid` | 400 | `POST /tasks/:id/end` |
+| `task_not_found` | 404 | `POST /tasks/:id/end`, any passthrough surface |
+| `task_owner_forbidden` | 403 | `POST /tasks/:id/end`, any passthrough surface |
+| `task_already_closed` | 409 | `POST /tasks/:id/end` |
+| `task_publish_failed` | 400 | `POST /tasks/:id/end` (partial-publish body) |
+
+Legacy endpoints (`/knowledge/*` without task-session semantics) return `{ error }` without a `code`. New error surfaces added after A1 should follow the `{ error, code }` pattern.
+
+---
+
+## Observability: what gets written to `usage_events` and `reuse_feedback`
+
+This is useful context for dashboard and report consumers:
+
+- `query_knowledge` / `semantic_search` / `start_task` each write **one** `usage_events` row with `event_type='query'` carrying `query_text` (raw), `result_count`, `project`, `search_mode`, and a `request_id`.
+- Each item returned in a search response writes **one** `usage_events` row with `event_type='exposure'` sharing the parent `request_id`.
+- `get_knowledge` writes **one** `usage_events` row with `event_type='view'`, carrying optional `query_context` and `task_id`.
+- `reuse_feedback` writes **one** row in the dedicated `reuse_feedback` table, carrying `verdict`, `comment`, and optional `task_id`.
+- `end_task(findings)` writes one `task_publications(task_id, knowledge_id)` row per successfully published finding, in the same transaction as the `knowledge` insert.
+
+Reports prioritize `view` + `reuse_feedback` over `exposure` for reuse metrics. Exposure is tracked for search-effectiveness analysis only.

--- a/docs/api.md
+++ b/docs/api.md
@@ -262,7 +262,7 @@ Open a task session. **Auth required.**
 |---|---|---|---|
 | `description` | string | yes | Non-empty after trim. Can contain arbitrary punctuation and operator-like words; FTS sanitization is internal. |
 | `project` | string | no | Scope hybrid search to a project |
-| `max_matches` | integer | no | Range `[1, 100]`, default `10` |
+| `max_matches` | integer | no | Range `[1, 100]` at the REST layer, default `10`. The MCP bridge exposes a narrower `[1, 50]` cap — agents calling `start_task` via MCP will hit a client-side validation error above 50. Direct REST callers can use the full `[1, 100]` range. |
 
 The session is persisted with the **raw** description (before sanitization). Hybrid search runs with `search_mode: "hybrid"` and is recorded as a `query` event with `task_id` linked.
 


### PR DESCRIPTION
## M-docs batch: align README + add `docs/api.md` for A1 task sessions + reuse tracking

Closes the M-docs slice of the A1 implementation lane. Rebased on `main@56e10bc` — the A1 full chain (schema + endpoints + hotfix + MCP) is landed before this doc batch opens, so every surface documented here is already observable in code.

### A1 implementation lineage (for readers arriving here cold)

| Slice | PR | Squash SHA |
|---|---|---|
| Schema + migrations (`tasks`, `task_publications`, `task_id` columns) | #48 | `d2fc5a0` |
| REST endpoints (`/api/tasks/start`, `/api/tasks/:task_id/end`, `task_id?` passthrough) | #51 | `1aefcf4` |
| Hotfix (`start_task` FTS sanitization + whitespace `400`) | #52 | `0d2ea71` |
| MCP layer (9 tools, partial-failure body surfacing) | #50 | `56e10bc` |

### What this PR changes

1. **`README.md` overview** (commit `ec0dc1e`)
   - Replaces the stale "Phase 1 ships four pieces" narrative with the current architecture (vector-hybrid search, task sessions, reuse tracking, admin CLI)
   - Regroups the MCP Tools section into reads / writes / reuse signal / task sessions and lists all 9 tools
   - Replaces the 5-endpoint REST list with the current surface grouped by purpose and points to `docs/api.md` for the full reference
   - Recommends `start_task` + `reuse_feedback` at the top of the agent workflow
   - Replaces "Current Phase 1 Status" with actual status (vector search, auth, reuse tracking, task sessions all shipped)
   - Adds `e2e/scripts/reuse-loop.ts` to the E2E Validation section

2. **`docs/api.md` new file** (commit `6e24d3f`)
   - Full wire-contract reference for the REST surface on `main@0d2ea71`+`56e10bc`
   - Sections: base URL + auth postures (required / optional read-tracking / optional passthrough), health, knowledge CRUD, FTS + semantic search, reuse feedback, task sessions (incl. partial-publish body + closed-session-as-valid-linkage-target), reports (reuse snapshot with M1b params), error code catalog, observability appendix
   - Cross-links to `docs/agent-protocol.md` for workflow guidance — this file stays a wire-contract reference only

3. **`docs/api.md` MCP `max_matches` cap note** (commit `f52a472`)
   - Documents the intentional MCP narrowing (`[1, 50]`) vs REST range (`[1, 100]`) per Ed's ack in msg `71369263`

### Intentional scope split

The four docs touched across this A1 cascade split cleanly:

| File | Owner PR | Purpose |
|---|---|---|
| `README.md` | this PR | High-level repo overview, package layout, quick start |
| `docs/api.md` | this PR | REST wire-contract reference |
| `docs/agent-protocol.md` | PR #50 | Agent workflow + behavioral protocol |
| `docs/system-prompt-snippet.md` | PR #50 | Embeddable system-prompt snippet |

### Non-blocking observations surfaced upstream, tracked in docs

- **`max_matches` MCP cap 50 vs REST 100** — Spike PR #50 review comment `c21203a3` → Ed ack `71369263` → now documented in `docs/api.md` `max_matches` row (commit `f52a472`).
- **`endTask` partial-failure shape-matching** — Spike PR #50 review comment `c21203a3` → Ed tracked as **issue #53** (deferred until after A2 lands).

### Testing

Docs-only change; no code paths touched.

- README renders cleanly (manual GitHub markdown preview).
- `docs/api.md` references only endpoints present on `main@56e10bc`. Every error code in the catalog appears in `packages/backend/src/routes.ts` at the cited status (manual grep-verified against `jsonTaskError` call sites).
- Internal cross-links (`docs/api.md` ↔ `docs/agent-protocol.md` ↔ `README.md`) all resolve.
