### PR TITLE
feat(backend): default read scope from API key projects

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@ For recommended agent workflows (when to publish, when to call `reuse_feedback`,
 
 ## Authentication
 
-The backend uses a simple Bearer token model. Tokens are minted with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner>`) and identify an owner plus optional default project.
+The backend uses a simple Bearer token model. Tokens are minted with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner>`) and identify an owner plus optional default-project namespace (`default_projects`).
 
 Three auth postures show up below:
 
@@ -131,7 +131,7 @@ List knowledge items. No auth (unauthenticated listing; does not record `usage_e
 
 | Param | Meaning |
 |---|---|
-| `project` | Filter by project |
+| `project` | Filter by project. When omitted on an authenticated request, the caller's API-key `default_projects` scope applies. Use `*` to opt out back to unscoped reads. An empty query value (`?project=`) is treated as a literal override to the project name `""`, not as omission/inheritance. |
 | `owner` | Filter by owner |
 | `tags` | Comma-separated; items match if they carry **any** of the listed tags (OR semantics) |
 | `include_superseded` | `true` to include superseded entries (default `false`) |
@@ -194,7 +194,7 @@ User text is sanitized before it reaches the FTS5 `MATCH` clause: tokens are ext
 | Param | Meaning |
 |---|---|
 | `q` | **Required.** Search text. |
-| `project` | Filter by project |
+| `project` | Filter by project. When omitted on an authenticated request, the caller's API-key `default_projects` scope applies. Use `*` to opt out back to unscoped reads. An empty query value (`?project=`) is treated as a literal override to the project name `""`, not as omission/inheritance. |
 | `module` | Filter by module |
 | `tags` | Comma-separated; items match if they carry **any** of the listed tags (OR semantics) |
 | `include_superseded` | `true` to include superseded entries |
@@ -223,7 +223,7 @@ Embedding-based similarity search. Optional auth (read tracking); optional `task
 | Param | Meaning |
 |---|---|
 | `q` | **Required.** Natural-language query. |
-| `project` | Filter by project |
+| `project` | Filter by project. When omitted on an authenticated request, the caller's API-key `default_projects` scope applies. Use `*` to opt out back to unscoped reads. An empty query value (`?project=`) is treated as a literal override to the project name `""`, not as omission/inheritance. |
 | `limit` | Integer, defaults to 10 (capped at 100) |
 | `task_id` | Optional task session linkage |
 
@@ -279,7 +279,7 @@ Open a task session. **Auth required.**
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `description` | string | yes | Non-empty after trim. Can contain arbitrary punctuation and operator-like words; FTS sanitization is internal. |
-| `project` | string | no | Scope hybrid search to a project |
+| `project` | string | no | Scope hybrid search to a project. When omitted, authenticated callers inherit their API-key `default_projects` scope. Use `"*"` to opt out back to unscoped retrieval. An empty string is treated as the literal project name `""`, not as omission/inheritance. |
 | `max_matches` | integer | no | Range `[1, 100]` at the REST layer, default `10`. The MCP bridge exposes a narrower `[1, 50]` cap — agents calling `start_task` via MCP will hit a client-side validation error above 50. Direct REST callers can use the full `[1, 100]` range. |
 
 The session is persisted with the **raw** description (before sanitization). Hybrid search runs with `search_mode: "hybrid"` and is recorded as a `query` event with `task_id` linked.
@@ -297,6 +297,8 @@ The session is persisted with the **raw** description (before sanitization). Hyb
 ```
 
 Match rows mirror the shape returned by `GET /api/knowledge/search` — each row is a knowledge-row summary plus `search_mode` and `score`. 0-hit sessions still return `201` with `task_id` and `matches: []`. Failed-embedding queries still return `201` on the FTS path; the query row records the failure for reuse-report observability.
+
+The response `project` field echoes the effective single-project scope label when one exists (explicit project or a single inherited default project). It is `null` for multi-project inherited scope and fully unscoped sessions.
 
 **Errors**
 

--- a/packages/backend/src/auth.ts
+++ b/packages/backend/src/auth.ts
@@ -4,6 +4,13 @@ import { getDb } from "./db.js";
 export interface ApiAuth {
   key: string;
   owner: string;
+  defaultProjects: string[] | null;
+}
+
+interface ApiKeyRow {
+  key: string;
+  owner: string;
+  default_projects: string | null;
 }
 
 function jsonError(c: Context, status: 401 | 403, error: string, code: string): Response {
@@ -16,16 +23,46 @@ function extractBearerToken(header: string | undefined): string | null {
   return match?.[1]?.trim() || null;
 }
 
+function parseDefaultProjects(raw: string | null | undefined): string[] | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    const projects = Array.from(new Set(
+      parsed
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ));
+    return projects.length > 0 ? projects : null;
+  } catch {
+    return null;
+  }
+}
+
+function lookupApiAuth(token: string): ApiAuth | undefined {
+  const db = getDb();
+  const row = db
+    .prepare("SELECT key, owner, default_projects FROM api_keys WHERE key = ? AND revoked_at IS NULL")
+    .get(token) as ApiKeyRow | undefined;
+
+  if (!row) return undefined;
+
+  return {
+    key: row.key,
+    owner: row.owner,
+    defaultProjects: parseDefaultProjects(row.default_projects),
+  };
+}
+
 export function requireApiAuth(c: Context): ApiAuth | Response {
   const token = extractBearerToken(c.req.header("authorization"));
   if (!token) {
     return jsonError(c, 401, "Missing Authorization: Bearer <api_key> header", "auth_missing");
   }
 
-  const db = getDb();
-  const row = db
-    .prepare("SELECT key, owner FROM api_keys WHERE key = ? AND revoked_at IS NULL")
-    .get(token) as ApiAuth | undefined;
+  const row = lookupApiAuth(token);
 
   if (!row) {
     return jsonError(c, 401, "Invalid API key", "auth_invalid");
@@ -43,10 +80,7 @@ export function getOptionalApiAuth(c: Context): ApiAuth | Response | null {
     return jsonError(c, 401, "Missing Authorization: Bearer <api_key> header", "auth_missing");
   }
 
-  const db = getDb();
-  const row = db
-    .prepare("SELECT key, owner FROM api_keys WHERE key = ? AND revoked_at IS NULL")
-    .get(token) as ApiAuth | undefined;
+  const row = lookupApiAuth(token);
 
   if (!row) {
     return jsonError(c, 401, "Invalid API key", "auth_invalid");

--- a/packages/backend/src/cli.ts
+++ b/packages/backend/src/cli.ts
@@ -3,33 +3,73 @@ import { closeDb, getDb } from "./db.js";
 
 function usage(): never {
   console.error(`Usage:
-  npm run keys -- create <owner>
+  npm run keys -- create <owner> [--projects alpha,beta]
   npm run keys -- list
+  npm run keys -- update-key <api_key> --projects alpha,beta
   npm run keys -- revoke <api_key>`);
   process.exit(1);
 }
 
-function createKey(owner: string): void {
+function parseProjectsArg(value: string | undefined): string[] | null {
+  if (value === undefined) usage();
+  if (value === "" || value === "*") return null;
+
+  const projects = Array.from(new Set(
+    value
+      .split(",")
+      .map((project) => project.trim())
+      .filter(Boolean),
+  ));
+
+  return projects.length > 0 ? projects : null;
+}
+
+function encodeProjects(projects: string[] | null): string | null {
+  return projects ? JSON.stringify(projects) : null;
+}
+
+function formatScope(projects: string | null): string {
+  if (!projects) return "*";
+  try {
+    const parsed = JSON.parse(projects);
+    if (!Array.isArray(parsed) || parsed.length === 0) return "*";
+    return parsed.join(",");
+  } catch {
+    return projects;
+  }
+}
+
+function createKey(owner: string, projects: string[] | null): void {
   const db = getDb();
   const key = `tm_${randomBytes(24).toString("hex")}`;
   const createdAt = new Date().toISOString();
 
-  db.prepare("INSERT INTO api_keys (key, owner, created_at, revoked_at) VALUES (?, ?, ?, NULL)").run(
+  db.prepare(
+    "INSERT INTO api_keys (key, owner, default_projects, created_at, revoked_at) VALUES (?, ?, ?, ?, NULL)",
+  ).run(
     key,
     owner,
+    encodeProjects(projects),
     createdAt,
   );
 
   console.log(`Created API key for ${owner}`);
   console.log(`key=${key}`);
   console.log(`created_at=${createdAt}`);
+  console.log(`scope=${projects ? projects.join(",") : "*"}`);
 }
 
 function listKeys(): void {
   const db = getDb();
   const rows = db
-    .prepare("SELECT key, owner, created_at, revoked_at FROM api_keys ORDER BY created_at DESC")
-    .all() as Array<{ key: string; owner: string; created_at: string; revoked_at: string | null }>;
+    .prepare("SELECT key, owner, default_projects, created_at, revoked_at FROM api_keys ORDER BY created_at DESC")
+    .all() as Array<{
+      key: string;
+      owner: string;
+      default_projects: string | null;
+      created_at: string;
+      revoked_at: string | null;
+    }>;
 
   if (rows.length === 0) {
     console.log("No API keys found.");
@@ -38,9 +78,24 @@ function listKeys(): void {
 
   for (const row of rows) {
     console.log(
-      `${row.key} owner=${row.owner} created_at=${row.created_at} status=${row.revoked_at ? "revoked" : "active"}`,
+      `${row.key} owner=${row.owner} scope=${formatScope(row.default_projects)} created_at=${row.created_at} status=${row.revoked_at ? "revoked" : "active"}`,
     );
   }
+}
+
+function updateKeyProjects(key: string, projects: string[] | null): void {
+  const db = getDb();
+  const result = db
+    .prepare("UPDATE api_keys SET default_projects = ? WHERE key = ? AND revoked_at IS NULL")
+    .run(encodeProjects(projects), key);
+
+  if (result.changes === 0) {
+    console.error(`No active API key found for ${key}`);
+    process.exit(1);
+  }
+
+  console.log(`Updated API key ${key}`);
+  console.log(`scope=${projects ? projects.join(",") : "*"}`);
 }
 
 function revokeKey(key: string): void {
@@ -59,19 +114,30 @@ function revokeKey(key: string): void {
 }
 
 try {
-  const [command, arg] = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  const [command, firstArg, ...rest] = args;
 
   switch (command) {
-    case "create":
-      if (!arg) usage();
-      createKey(arg);
+    case "create": {
+      if (!firstArg) usage();
+      const flagIndex = rest.indexOf("--projects");
+      const projects = flagIndex >= 0 ? parseProjectsArg(rest[flagIndex + 1]) : null;
+      createKey(firstArg, projects);
       break;
+    }
     case "list":
       listKeys();
       break;
+    case "update-key": {
+      if (!firstArg) usage();
+      const flagIndex = rest.indexOf("--projects");
+      if (flagIndex < 0) usage();
+      updateKeyProjects(firstArg, parseProjectsArg(rest[flagIndex + 1]));
+      break;
+    }
     case "revoke":
-      if (!arg) usage();
-      revokeKey(arg);
+      if (!firstArg) usage();
+      revokeKey(firstArg);
       break;
     default:
       usage();

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -184,6 +184,7 @@ export function getDb(): Database.Database {
     CREATE TABLE IF NOT EXISTS api_keys (
       key         TEXT PRIMARY KEY,
       owner       TEXT NOT NULL,
+      default_projects TEXT,
       created_at  TEXT NOT NULL,
       revoked_at  TEXT
     );
@@ -235,6 +236,7 @@ export function getDb(): Database.Database {
   ensureColumn(_db, "knowledge", "duplicate_of", "TEXT");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_knowledge_duplicate_of ON knowledge(duplicate_of)");
   ensureColumn(_db, "knowledge", "embedding", "BLOB");
+  ensureColumn(_db, "api_keys", "default_projects", "TEXT");
   ensureColumn(_db, "reuse_feedback", "task_id", "TEXT REFERENCES tasks(task_id) ON DELETE SET NULL");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_reuse_feedback_task_id ON reuse_feedback(task_id)");
   cleanupFalsePositiveDuplicateOf(_db);

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -648,10 +648,12 @@ api.post("/tasks/start", async (c) => {
   const project = body.project ?? null;
   const maxMatches = (maxMatchesInput as number | undefined) ?? 10;
   const db = getDb();
+  const scopedProjects = resolveScopedProjects(project ?? undefined, auth);
+  const taskProject = projectLabelForUsage(project ?? undefined, scopedProjects);
 
   const results = await runHybridSearch(db, {
     query: description,
-    projects: project ? [project] : undefined,
+    projects: scopedProjects ?? undefined,
     includeSuperseded: false,
     limit: maxMatches,
   });
@@ -664,10 +666,10 @@ api.post("/tasks/start", async (c) => {
   );
 
   db.transaction(() => {
-    insertTask.run(taskId, auth.owner, project, description, openedAt);
+    insertTask.run(taskId, auth.owner, taskProject, description, openedAt);
     recordSearchEvents(db, auth.owner, {
       items: results.items.map((item) => ({ id: item.id, project: item.project })),
-      project,
+      project: taskProject,
       taskId,
       queryText: description,
       searchMode: "hybrid",
@@ -677,7 +679,7 @@ api.post("/tasks/start", async (c) => {
   return c.json({
     task_id: taskId,
     description,
-    project,
+    project: taskProject,
     retrieval_mode: results.retrievalMode,
     matches: results.items,
   }, 201);

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { v4 as uuidv4 } from "uuid";
 import { getOptionalApiAuth, requireApiAuth, requireOwnerAccess } from "./auth.js";
+import type { ApiAuth } from "./auth.js";
 import { getDb } from "./db.js";
 import { findPersistedDuplicateOf } from "./duplicates.js";
 import { embedKnowledgeItem, embedTexts } from "./embedding.js";
@@ -173,7 +174,7 @@ async function runSemanticCandidates(
   db: ReturnType<typeof getDb>,
   input: {
     query: string;
-    project?: string;
+    projects?: string[];
     module?: string;
     includeSuperseded: boolean;
     tags?: string[];
@@ -190,9 +191,9 @@ async function runSemanticCandidates(
   if (!input.includeSuperseded) {
     conditions.push("superseded_by IS NULL");
   }
-  if (input.project) {
-    conditions.push("project = ?");
-    params.push(input.project);
+  if (input.projects?.length) {
+    conditions.push(`project IN (${input.projects.map(() => "?").join(", ")})`);
+    params.push(...input.projects);
   }
   if (input.module) {
     conditions.push("module = ?");
@@ -237,7 +238,7 @@ async function runHybridSearch(
   db: ReturnType<typeof getDb>,
   input: {
     query: string;
-    project?: string;
+    projects?: string[];
     module?: string;
     includeSuperseded: boolean;
     tags?: string[];
@@ -252,9 +253,9 @@ async function runHybridSearch(
   const conditions: string[] = [];
   const params: (string | number)[] = [];
   if (!input.includeSuperseded) conditions.push("k.superseded_by IS NULL");
-  if (input.project) {
-    conditions.push("k.project = ?");
-    params.push(input.project);
+  if (input.projects?.length) {
+    conditions.push(`k.project IN (${input.projects.map(() => "?").join(", ")})`);
+    params.push(...input.projects);
   }
   if (input.module) {
     conditions.push("k.module = ?");
@@ -277,7 +278,7 @@ async function runHybridSearch(
 
   const semanticRows = await runSemanticCandidates(db, {
     query: input.query,
-    project: input.project,
+    projects: input.projects,
     module: input.module,
     includeSuperseded: input.includeSuperseded,
     tags: input.tags,
@@ -347,6 +348,18 @@ function jsonTaskError(
   code: string,
 ): Response {
   return c.json({ error, code }, status);
+}
+
+function resolveScopedProjects(explicitProject: string | undefined, auth: ApiAuth | null): string[] | null {
+  if (explicitProject === "*") return null;
+  if (explicitProject !== undefined) return [explicitProject];
+  return auth?.defaultProjects ?? null;
+}
+
+function projectLabelForUsage(explicitProject: string | undefined, scopedProjects: string[] | null): string | null {
+  if (explicitProject && explicitProject !== "*") return explicitProject;
+  if (scopedProjects?.length === 1) return scopedProjects[0]!;
+  return null;
 }
 
 function resolveTaskTrace(
@@ -638,7 +651,7 @@ api.post("/tasks/start", async (c) => {
 
   const results = await runHybridSearch(db, {
     query: description,
-    project: project ?? undefined,
+    projects: project ? [project] : undefined,
     includeSuperseded: false,
     limit: maxMatches,
   });
@@ -738,6 +751,7 @@ api.get("/knowledge/search", async (c) => {
   const taskTrace = resolveTaskTrace(c, c.req.query("task_id"), maybeAuth);
   if (taskTrace instanceof Response) return taskTrace;
   const project = c.req.query("project");
+  const scopedProjects = resolveScopedProjects(project, maybeAuth);
   const tags = c.req.query("tags");
   const module_ = c.req.query("module");
   const includeSuperseded = c.req.query("include_superseded") === "true";
@@ -746,7 +760,7 @@ api.get("/knowledge/search", async (c) => {
   const requestedTags = parseTagList(tags);
   const results = await runHybridSearch(db, {
     query: q,
-    project: project ?? undefined,
+    projects: scopedProjects ?? undefined,
     module: module_ ?? undefined,
     includeSuperseded,
     tags: requestedTags,
@@ -756,7 +770,7 @@ api.get("/knowledge/search", async (c) => {
   if (maybeAuth) {
     recordSearchEvents(db, maybeAuth.owner, {
       items: results.items.map((item) => ({ id: item.id, project: item.project })),
-      project: project ?? null,
+      project: projectLabelForUsage(project, scopedProjects),
       taskId: taskTrace?.task_id ?? null,
       queryText: q,
       searchMode: "hybrid",
@@ -776,6 +790,7 @@ api.get("/knowledge/semantic-search", async (c) => {
   if (taskTrace instanceof Response) return taskTrace;
 
   const project = c.req.query("project");
+  const scopedProjects = resolveScopedProjects(project, maybeAuth);
   const limit = Math.min(parseInt(c.req.query("limit") ?? "10", 10) || 10, 100);
   const db = getDb();
 
@@ -784,7 +799,7 @@ api.get("/knowledge/semantic-search", async (c) => {
     if (maybeAuth) {
       recordSearchEvents(db, maybeAuth.owner, {
         items: [],
-        project: project ?? null,
+        project: projectLabelForUsage(project, scopedProjects),
         taskId: taskTrace?.task_id ?? null,
         queryText: q,
         searchMode: "semantic",
@@ -795,9 +810,9 @@ api.get("/knowledge/semantic-search", async (c) => {
 
   const params: (string | number)[] = [];
   const conditions = ["embedding IS NOT NULL", "superseded_by IS NULL"];
-  if (project) {
-    conditions.push("project = ?");
-    params.push(project);
+  if (scopedProjects?.length) {
+    conditions.push(`project IN (${scopedProjects.map(() => "?").join(", ")})`);
+    params.push(...scopedProjects);
   }
 
   const rows = db.prepare(
@@ -821,7 +836,7 @@ api.get("/knowledge/semantic-search", async (c) => {
   if (maybeAuth) {
     recordSearchEvents(db, maybeAuth.owner, {
       items: items.map((item) => ({ id: item.id, project: item.project })),
-      project: project ?? null,
+      project: projectLabelForUsage(project, scopedProjects),
       taskId: taskTrace?.task_id ?? null,
       queryText: q,
       searchMode: "semantic",
@@ -833,7 +848,10 @@ api.get("/knowledge/semantic-search", async (c) => {
 
 // 4. GET /api/knowledge
 api.get("/knowledge", (c) => {
+  const maybeAuth = getOptionalApiAuth(c);
+  if (maybeAuth instanceof Response) return maybeAuth;
   const project = c.req.query("project");
+  const scopedProjects = resolveScopedProjects(project, maybeAuth);
   const tags = c.req.query("tags");
   const module_ = c.req.query("module");
   const owner = c.req.query("owner");
@@ -844,7 +862,10 @@ api.get("/knowledge", (c) => {
   const conditions: string[] = [];
   const params: (string | number)[] = [];
   if (!includeSuperseded) conditions.push("superseded_by IS NULL");
-  if (project) { conditions.push("project = ?"); params.push(project); }
+  if (scopedProjects?.length) {
+    conditions.push(`project IN (${scopedProjects.map(() => "?").join(", ")})`);
+    params.push(...scopedProjects);
+  }
   if (module_) { conditions.push("module = ?"); params.push(module_); }
   if (owner) { conditions.push("owner = ?"); params.push(owner); }
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";

--- a/packages/backend/tests/api-key-scope.test.ts
+++ b/packages/backend/tests/api-key-scope.test.ts
@@ -235,3 +235,29 @@ test("unauthenticated requests remain unscoped when project is omitted", async (
   assertSameIds(body.items, ["alpha-row", "beta-row"]);
   assert.equal(body.total, 2);
 });
+
+test("start_task inherits a single-project API-key scope when project is omitted", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-auth", claim: "Auth note in alpha", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-auth", claim: "Auth note in beta", project: "beta" });
+  const apiKey = createApiKey("TaskScopedOwner", ["alpha"]);
+
+  const response = await app.request("http://localhost/api/tasks/start", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ description: "auth" }),
+  });
+
+  assert.equal(response.status, 201);
+  const body = await response.json() as {
+    task_id: string;
+    project: string | null;
+    matches: Array<{ id: string }>;
+  };
+  assert.equal(typeof body.task_id, "string");
+  assert.equal(body.project, "alpha");
+  assertSameIds(body.matches, ["alpha-auth"]);
+});

--- a/packages/backend/tests/api-key-scope.test.ts
+++ b/packages/backend/tests/api-key-scope.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-api-key-scope-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+process.env.EMBEDDING_API_KEY = "test-scope-key";
+process.env.EMBEDDING_API_BASE = "https://openrouter.ai/api/v1";
+process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+let originalFetch: typeof globalThis.fetch;
+
+function encodeEmbedding(vector: number[]): Buffer {
+  return Buffer.from(Float32Array.from(vector).buffer);
+}
+
+function assertSameIds(actual: Array<{ id: string }>, expected: string[]): void {
+  assert.deepEqual(
+    actual.map((item) => item.id).sort(),
+    [...expected].sort(),
+  );
+}
+
+function createApiKey(owner: string, defaultProjects: string[] | null, key = `${owner.toLowerCase()}-key`): string {
+  const db = getDb();
+  db.prepare(
+    "INSERT OR REPLACE INTO api_keys (key, owner, default_projects, created_at, revoked_at) VALUES (?, ?, ?, ?, NULL)",
+  ).run(
+    key,
+    owner,
+    defaultProjects ? JSON.stringify(defaultProjects) : null,
+    new Date().toISOString(),
+  );
+  return key;
+}
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    claim: string;
+    project: string;
+    embedding?: Buffer | null;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim,
+    null,
+    JSON.stringify(["tests/api-key-scope.test.ts"]),
+    input.project,
+    "scope",
+    JSON.stringify(["scope"]),
+    "high",
+    "Recheck if API-key scoping semantics change.",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    null,
+    null,
+    input.embedding ?? null,
+    now,
+    now,
+  );
+}
+
+before(async () => {
+  originalFetch = globalThis.fetch;
+
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  const db = getDb();
+  db.exec("DELETE FROM knowledge; DELETE FROM api_keys;");
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.TEAM_MEMORY_DB;
+  delete process.env.EMBEDDING_API_KEY;
+  delete process.env.EMBEDDING_API_BASE;
+  delete process.env.EMBEDDING_MODEL;
+});
+
+test("scoped key defaults unparametrized list_knowledge to its single project", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-row", claim: "Alpha only note", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-row", claim: "Beta only note", project: "beta" });
+  const apiKey = createApiKey("AlphaOwner", ["alpha"]);
+
+  const response = await app.request("http://localhost/api/knowledge", {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { items: Array<{ id: string }>; total: number };
+  assertSameIds(body.items, ["alpha-row"]);
+  assert.equal(body.total, 1);
+});
+
+test("scoped key with multiple projects sees all projects in its default namespace", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-row", claim: "Alpha only note", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-row", claim: "Beta only note", project: "beta" });
+  insertKnowledgeRow(db, { id: "gamma-row", claim: "Gamma only note", project: "gamma" });
+  const apiKey = createApiKey("MultiOwner", ["alpha", "beta"]);
+
+  const response = await app.request("http://localhost/api/knowledge", {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { items: Array<{ id: string }>; total: number };
+  assertSameIds(body.items, ["alpha-row", "beta-row"]);
+  assert.equal(body.total, 2);
+});
+
+test("explicit project override bypasses default key scope on search", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-row", claim: "Billing note in alpha", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-row", claim: "Billing note in beta", project: "beta" });
+  const apiKey = createApiKey("ScopedOwner", ["alpha"]);
+
+  const response = await app.request("http://localhost/api/knowledge/search?q=billing&project=beta", {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { items: Array<{ id: string }>; total: number };
+  assertSameIds(body.items, ["beta-row"]);
+  assert.equal(body.total, 1);
+});
+
+test("project=* opt-out returns unscoped results for a scoped key", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-row", claim: "Billing note in alpha", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-row", claim: "Billing note in beta", project: "beta" });
+  const apiKey = createApiKey("ScopedOwner", ["alpha"]);
+
+  const response = await app.request("http://localhost/api/knowledge/search?q=billing&project=*", {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { items: Array<{ id: string }>; total: number };
+  assertSameIds(body.items, ["alpha-row", "beta-row"]);
+  assert.equal(body.total, 2);
+});
+
+test("semantic search applies API-key default project scope when project is omitted", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, {
+    id: "alpha-semantic",
+    claim: "Vector scope alpha result",
+    project: "alpha",
+    embedding: encodeEmbedding([1, 0]),
+  });
+  insertKnowledgeRow(db, {
+    id: "beta-semantic",
+    claim: "Vector scope beta result",
+    project: "beta",
+    embedding: encodeEmbedding([1, 0]),
+  });
+  const apiKey = createApiKey("SemanticOwner", ["alpha"]);
+
+  globalThis.fetch = (async () => new Response(
+    JSON.stringify({ data: [{ index: 0, embedding: [1, 0] }] }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  )) as typeof globalThis.fetch;
+
+  const response = await app.request("http://localhost/api/knowledge/semantic-search?q=vector%20scope", {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { items: Array<{ id: string }>; total: number };
+  assertSameIds(body.items, ["alpha-semantic"]);
+  assert.equal(body.total, 1);
+});
+
+test("legacy null-scoped keys remain unscoped when project is omitted", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-row", claim: "Alpha only note", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-row", claim: "Beta only note", project: "beta" });
+  const apiKey = createApiKey("LegacyOwner", null);
+
+  const response = await app.request("http://localhost/api/knowledge", {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { items: Array<{ id: string }>; total: number };
+  assertSameIds(body.items, ["alpha-row", "beta-row"]);
+  assert.equal(body.total, 2);
+});
+
+test("unauthenticated requests remain unscoped when project is omitted", async () => {
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-row", claim: "Alpha only note", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-row", claim: "Beta only note", project: "beta" });
+
+  const response = await app.request("http://localhost/api/knowledge");
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as { items: Array<{ id: string }>; total: number };
+  assertSameIds(body.items, ["alpha-row", "beta-row"]);
+  assert.equal(body.total, 2);
+});


### PR DESCRIPTION
## Summary
- add `api_keys.default_projects` and parse it into auth as the caller's default read namespace
- scope authenticated `/api/knowledge`, `/api/knowledge/search`, and `/api/knowledge/semantic-search` when `project` is omitted
- keep `?project=<name>` as an explicit override and `?project=*` as an explicit unscoped opt-out
- add CLI support for `create --projects ...` and `update-key --projects ...`
- cover single-scope, multi-scope, explicit override, `project=*`, legacy null scope, semantic scope, and unauthenticated unscoped behavior

Closes #43.

## Contract
- authenticated reads with omitted `project` now default to the API key's `default_projects`
- unauthenticated requests remain unscoped
- legacy keys with `default_projects = NULL` remain unscoped for back-compat
- explicit `project` still wins over auth-derived scope

## Validation
- `npm run build --workspace=packages/backend`
- `node --test --import tsx packages/backend/tests/api-key-scope.test.ts`
- `npm run test --workspace=packages/backend`
