### PR TITLE
ops: anonymous-pull smoke workflow (cron + post-Docker)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,98 @@
+name: Anonymous Pull Smoke
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_run:
+    workflows: [Docker]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}:latest
+
+    steps:
+      - name: Ensure anonymous (no registry auth)
+        run: docker logout ghcr.io || true
+
+      - name: Anonymous pull
+        run: docker pull --platform linux/amd64 "$IMAGE"
+
+      - name: Boot + /health
+        run: |
+          docker run -d --platform linux/amd64 --name tm-smoke -p 3456:3456 "$IMAGE"
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:3456/health > /dev/null; then
+              echo "Health check OK"
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "Health check failed after 30s"
+              docker logs tm-smoke
+              exit 1
+            fi
+            sleep 1
+          done
+          BODY=$(curl -s http://127.0.0.1:3456/health)
+          echo "Response: $BODY"
+          if [ "$BODY" != '{"status":"ok"}' ]; then
+            echo "Unexpected health body"
+            docker logs tm-smoke
+            exit 1
+          fi
+          docker logs tm-smoke
+          docker stop tm-smoke
+          docker rm tm-smoke
+
+      - name: File regression issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          TRIGGER: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const title = 'deploy/smoke: anonymous pull or /health failed';
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'deploy-smoke',
+              per_page: 5,
+            });
+            const body = [
+              `Anonymous-pull smoke failed.`,
+              ``,
+              `- Trigger: \`${process.env.TRIGGER}\``,
+              `- Run: ${process.env.RUN_URL}`,
+              `- Image: \`${process.env.IMAGE || 'ghcr.io/' + context.repo.owner + '/' + context.repo.repo + ':latest'}\``,
+              ``,
+              `Possible causes: GHCR visibility reverted, image broken on latest main, registry/CDN regression, or /health endpoint regression.`,
+            ].join('\n');
+            if (existing.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['deploy-smoke'],
+              });
+            }


### PR DESCRIPTION
## Summary

Defensive regression gate for the public GHCR image. Runs anonymous `docker pull` + boot + `/health` on a schedule and after every successful main-branch Docker build, so we learn fast if the image becomes unpullable or unbootable for strangers.

Closes the feedback loop opened by A4 / #44 — the Docker workflow only verifies the build produces a working image, not that the **published** image stays pullable and bootable from an anonymous client.

## What this catches that `docker.yml` can't

1. **Anonymous pull breakage** — GHCR visibility reverted to private, registry auth regression, etc. `docker.yml` logs in with `GITHUB_TOKEN`, so it never exercises the unauth path.
2. **Registry / CDN propagation failures** — tag exists in GHCR API but 404s on CDN, or new layer push didn't propagate.
3. **Post-publish boot regressions** — build-stage smoke runs on `team-memory:ci` (locally-loaded), not on the manifest that was actually pushed.

## Triggers

- `schedule: cron '0 */6 * * *'` — 4× daily baseline check
- `workflow_run` on `Docker` success on `main` — immediate post-publish verification
- `workflow_dispatch` — manual re-run

## Failure surface

On failure, opens (or comments on the existing open) `deploy/smoke: …` issue labelled `deploy-smoke`, so regressions don't silently sit in the workflow-run list.

## Design choices

- Stays `linux/amd64` to match the published manifest (no arm64 via QEMU — not worth the flakiness for a smoke gate)
- Uses the same `/health` contract and retry-30 loop as `docker.yml` — identical success signal means no drift between build-stage and post-publish expectations
- No registry login — the *point* is to exercise the anonymous path that strangers actually use
- Skips execution when `workflow_run.conclusion != 'success'` so we don't double-report a build failure as a smoke failure

## Test plan

- [ ] Merge → next main push triggers the `workflow_run` path, should pass green within ~1 min
- [ ] Next `cron` firing (~19:00 UTC) confirms schedule path works
- [ ] Manually `workflow_dispatch` after merge to confirm dispatch path
- [ ] (Later, if a smoke fails in the wild) verify the regression-issue creation + comment-on-existing-issue flow both work

## Scope

Follow-up to A4 / #49. Tag: `P0-followup` — defensive infra, not on any P1 critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)