### PR TITLE
docs(api): inline POST examples for feedback + tasks/start

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -254,6 +254,17 @@ Record a verdict on a knowledge item. **Auth required.** Optional `task_id` link
 | `comment` | string | no | Free-form note |
 | `task_id` | string | no | Task session linkage |
 
+**Minimal valid request body**
+
+```json
+{
+  "verdict": "useful",
+  "comment": "Fixed my FTS5 tokenization question on first read."
+}
+```
+
+`verdict` is the only required field — the example above includes `comment` because feedback without a one-line justification is harder to audit later.
+
 **Response — 201**
 
 ```json
@@ -283,6 +294,17 @@ Open a task session. **Auth required.**
 | `max_matches` | integer | no | Range `[1, 100]` at the REST layer, default `10`. The MCP bridge exposes a narrower `[1, 50]` cap — agents calling `start_task` via MCP will hit a client-side validation error above 50. Direct REST callers can use the full `[1, 100]` range. |
 
 The session is persisted with the **raw** description (before sanitization). Hybrid search runs with `search_mode: "hybrid"` and is recorded as a `query` event with `task_id` linked.
+
+**Minimal valid request body**
+
+```json
+{
+  "description": "Investigate why FTS5 MATCH returns 0 hits on hyphenated tokens",
+  "project": "team-memory"
+}
+```
+
+`description` is the only required field. The example pins `project` to a single namespace for clarity — see the field table above for what `project` does when omitted.
 
 **Response — 201**
 


### PR DESCRIPTION
## Summary

- Adds a **Minimal valid request body** block + one-line context note after the fields table for `POST /api/knowledge/:id/feedback` and `POST /api/tasks/start`.
- Parallels the same block Spike folded into PR #54 for `POST /api/knowledge` (commit a271060).
- Closes the remaining two write surfaces in the usability gap surfaced during the pilot walkthrough: first-attempt seeders had no inline JSON to copy and had to reverse-engineer required fields from the field table + error responses.

## Scope discipline

- **No** schema-field expansions, **no** error-table edits, **no** response-shape changes.
- **No** forward-refs to unmerged work — the tasks/start example deliberately pins `project` to a single namespace and defers the omitted-project semantics to the field table (Ein's A2 docs delta on PR #55 cascade will add the dedicated scoping section; this PR doesn't race it).
- Example body for feedback includes `comment` — intentional (feedback without a one-line justification is harder to audit later).

## Authorization

Faye `fe2638f2` explicitly greenlit this follow-up with scope capped at "3 write surfaces, inline JSON example each." Spike's PR #54 merge (`d784a1c`) absorbed the first surface (`POST /api/knowledge`) as commit `a271060`, leaving the other two for this PR.

## Test plan

- [ ] CI green (docs-only change — smoke + docker should both pass trivially)
- [ ] Markdown renders correctly on GitHub (code fences, indentation)
- [ ] No broken links or dangling anchor refs