### PR TITLE
fix(mcp): tighten endTask partial-failure discriminator (#53)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "node --import tsx --test tests/**/*.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/packages/mcp-server/src/api-client.ts
+++ b/packages/mcp-server/src/api-client.ts
@@ -139,6 +139,13 @@ export interface EndTaskResponse {
   error?: EndTaskPartialError;
 }
 
+export function isEndTaskPartialFailure(parsed: unknown): parsed is EndTaskResponse {
+  if (!parsed || typeof parsed !== "object") return false;
+  const err = (parsed as { error?: unknown }).error;
+  if (!err || typeof err !== "object") return false;
+  return typeof (err as { failed_index?: unknown }).failed_index === "number";
+}
+
 export class ApiClient {
   private baseUrl: string;
   private apiKey?: string;
@@ -307,6 +314,11 @@ export class ApiClient {
     // Surface that body to the caller instead of throwing so the MCP handler
     // can render partial success richly. 404 / 403 / 409 use a bare error
     // payload and still throw.
+    //
+    // Discriminator is semantic, not shape-based: partial-failure is the only
+    // shape that carries `error.failed_index` per the locked contract, so we
+    // detect it directly rather than inferring from `task_id/status/published_ids`
+    // presence (which could collide if a future hard-error path echoes task_id).
     if (!res.ok) {
       let parsed: unknown = null;
       try {
@@ -314,13 +326,7 @@ export class ApiClient {
       } catch {
         // fall through to raw-text throw below
       }
-      if (
-        parsed &&
-        typeof parsed === "object" &&
-        "task_id" in parsed &&
-        "status" in parsed &&
-        "published_ids" in parsed
-      ) {
+      if (isEndTaskPartialFailure(parsed)) {
         return parsed as EndTaskResponse;
       }
       const text =

--- a/packages/mcp-server/tests/end-task-discriminator.test.ts
+++ b/packages/mcp-server/tests/end-task-discriminator.test.ts
@@ -9,7 +9,7 @@ test("isEndTaskPartialFailure: recognizes partial-failure envelope", () => {
     published_ids: ["k-1"],
     duration_ms: 42,
     error: {
-      code: "publish_failed",
+      code: "task_publish_failed",
       failed_index: 1,
       publish_status: 400,
       publish_error: "claim must be non-empty",
@@ -65,7 +65,7 @@ test("ApiClient.endTask: partial-failure non-2xx returns EndTaskResponse", async
     published_ids: ["k-1"],
     duration_ms: 42,
     error: {
-      code: "publish_failed",
+      code: "task_publish_failed",
       failed_index: 1,
       publish_status: 400,
       publish_error: "bad",

--- a/packages/mcp-server/tests/end-task-discriminator.test.ts
+++ b/packages/mcp-server/tests/end-task-discriminator.test.ts
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient, isEndTaskPartialFailure } from "../src/api-client.ts";
+
+test("isEndTaskPartialFailure: recognizes partial-failure envelope", () => {
+  const partial = {
+    task_id: "t-1",
+    status: "completed",
+    published_ids: ["k-1"],
+    duration_ms: 42,
+    error: {
+      code: "publish_failed",
+      failed_index: 1,
+      publish_status: 400,
+      publish_error: "claim must be non-empty",
+    },
+  };
+  assert.equal(isEndTaskPartialFailure(partial), true);
+});
+
+test("isEndTaskPartialFailure: rejects hard-error payloads that carry task_id", () => {
+  // Hypothetical future hard-error path that echoes task_id — the old shape-based
+  // discriminator would have mis-classified this as partial-failure.
+  const hardError = {
+    task_id: "t-1",
+    status: "already-closed",
+    published_ids: [],
+    error: "task_already_closed",
+  };
+  assert.equal(isEndTaskPartialFailure(hardError), false);
+});
+
+test("isEndTaskPartialFailure: rejects bare lifecycle errors (404/403/409)", () => {
+  for (const body of [
+    { error: "task_not_found" },
+    { error: "task_owner_mismatch", code: "owner_mismatch" },
+    { error: "task_already_closed", code: "already_closed" },
+  ]) {
+    assert.equal(isEndTaskPartialFailure(body), false);
+  }
+});
+
+test("isEndTaskPartialFailure: rejects error object without numeric failed_index", () => {
+  for (const body of [
+    { error: { code: "publish_failed" } },
+    { error: { code: "publish_failed", failed_index: "1" } },
+    { error: { code: "publish_failed", failed_index: null } },
+    { error: null },
+    { error: "string-error" },
+  ]) {
+    assert.equal(isEndTaskPartialFailure(body), false);
+  }
+});
+
+test("isEndTaskPartialFailure: rejects non-object inputs", () => {
+  for (const body of [null, undefined, 42, "string", true, []]) {
+    assert.equal(isEndTaskPartialFailure(body), false);
+  }
+});
+
+test("ApiClient.endTask: partial-failure non-2xx returns EndTaskResponse", async () => {
+  const partialBody = {
+    task_id: "t-1",
+    status: "completed",
+    published_ids: ["k-1"],
+    duration_ms: 42,
+    error: {
+      code: "publish_failed",
+      failed_index: 1,
+      publish_status: 400,
+      publish_error: "bad",
+    },
+  };
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(partialBody), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+  try {
+    const client = new ApiClient("http://localhost:9999", "test-key");
+    const result = await client.endTask({ task_id: "t-1", status: "completed" });
+    assert.equal(result.task_id, "t-1");
+    assert.equal(result.error?.failed_index, 1);
+    assert.deepEqual(result.published_ids, ["k-1"]);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test("ApiClient.endTask: hard error without failed_index throws", async () => {
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ error: "task_not_found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+  try {
+    const client = new ApiClient("http://localhost:9999", "test-key");
+    await assert.rejects(
+      client.endTask({ task_id: "missing", status: "completed" }),
+      /end_task failed \(404\)/,
+    );
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test("ApiClient.endTask: hard error with spurious task_id still throws (the #53 regression)", async () => {
+  // This is the exact case #53 was filed for: the old shape-based discriminator
+  // inferred "partial failure" from presence of task_id/status/published_ids.
+  // After the tightening, only error.failed_index presence triggers the
+  // partial-failure path.
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        task_id: "t-1",
+        status: "already-closed",
+        published_ids: [],
+        error: "task_already_closed",
+      }),
+      { status: 409, headers: { "Content-Type": "application/json" } },
+    )) as typeof fetch;
+  try {
+    const client = new ApiClient("http://localhost:9999", "test-key");
+    await assert.rejects(
+      client.endTask({ task_id: "t-1", status: "completed" }),
+      /end_task failed \(409\)/,
+    );
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- Replaces shape-based discriminator (`task_id && status && published_ids` presence) with semantic `error.failed_index` check in `ApiClient.endTask`
- `isEndTaskPartialFailure` type-guard helper exported from `api-client.ts` — partial-failure is the only contract-locked response shape that carries a numeric `failed_index`, so misclassification is impossible by spec
- Adds `packages/mcp-server/tests/` harness (node --test + tsx) matching the backend convention, plus 8 unit tests for the guard + round-trip

## Motivation
Follow-up from #50 (Spike non-blocking observation, deferred until A2 landed per #53). The old discriminator worked today because hard-error payloads (404/403/409) don't echo `task_id`, but it was implicit-by-convention rather than contract-enforced. Tightening to the semantic check makes the detection collision-proof as the backend error surface evolves.

## Changes
- `packages/mcp-server/src/api-client.ts`
  - New exported `isEndTaskPartialFailure(parsed: unknown): parsed is EndTaskResponse` guard
  - `endTask` non-2xx branch uses the guard; comment records the contract-locked invariant
- `packages/mcp-server/tests/end-task-discriminator.test.ts` (new)
  - 5 guard cases: valid partial, hard-error-with-spurious-task_id, bare lifecycle errors, non-numeric `failed_index`, non-object inputs
  - 3 round-trip cases via `ApiClient.endTask` with mocked `globalThis.fetch`: partial-body returns, hard error throws, hard error with spurious `task_id` still throws (this is the #53 regression)
- `packages/mcp-server/package.json`: add `test` script (`node --import tsx --test tests/**/*.test.ts`)

## Test plan
- [x] `npm run build --workspace=packages/mcp-server` green
- [x] `npm test --workspace=packages/mcp-server` → 8/8 pass
- [x] No behavior change on the happy path (partial-failure and hard-error branches both preserved) — only the discriminator is stricter
- [x] Single-file runtime change per #53 scope; no API contract change; no index.ts touch needed

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)