### PR TITLE
feat(cli): require explicit --projects or --unscoped on keys create/update-key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         id: apikey
         working-directory: packages/backend
         run: |
-          OUTPUT=$(npx tsx src/cli.ts create e2e-test)
+          OUTPUT=$(npx tsx src/cli.ts create e2e-test --unscoped)
           KEY=$(echo "$OUTPUT" | grep '^key=' | cut -d= -f2)
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ The backend key-management CLI uses the same env var, so point it at the same DB
 
 ```bash
 TEAM_MEMORY_DB=/absolute/path/to/team-memory.db \
-npm run keys --workspace=packages/backend -- create <owner>
+npm run keys --workspace=packages/backend -- create <owner> --projects alpha,beta
 ```
+
+The `create` and `update-key` subcommands require an explicit scope flag — pass `--projects <names>` to scope the key, or `--unscoped` to mint a key with no project restriction. Running without either flag fails loud rather than silently minting an unscoped key.
 
 ### 2. Start the MCP server
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@ For recommended agent workflows (when to publish, when to call `reuse_feedback`,
 
 ## Authentication
 
-The backend uses a simple Bearer token model. Tokens are minted with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner> --projects alpha,beta`) and identify an owner plus a default-project namespace (`default_projects`). The `create` and `update-key` subcommands require an explicit scope flag — either `--projects <names>` or `--unscoped`; there is no silent default to "unscoped".
+The backend uses a simple Bearer token model. Tokens are minted with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner> --projects alpha,beta`) and identify an owner plus an explicit scope posture: either a default-project namespace (`default_projects`: a non-empty `string[]`) when minted with `--projects <names>`, or no project restriction (`default_projects` is `null`) when minted with `--unscoped`. The `create` and `update-key` subcommands require one of those two flags; there is no silent default.
 
 Three auth postures show up below:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@ For recommended agent workflows (when to publish, when to call `reuse_feedback`,
 
 ## Authentication
 
-The backend uses a simple Bearer token model. Tokens are minted with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner>`) and identify an owner plus optional default-project namespace (`default_projects`).
+The backend uses a simple Bearer token model. Tokens are minted with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner> --projects alpha,beta`) and identify an owner plus a default-project namespace (`default_projects`). The `create` and `update-key` subcommands require an explicit scope flag — either `--projects <names>` or `--unscoped`; there is no silent default to "unscoped".
 
 Three auth postures show up below:
 

--- a/docs/mcp-config-template.md
+++ b/docs/mcp-config-template.md
@@ -7,6 +7,7 @@ This document provides ready-to-use configuration snippets for connecting an age
 1. The Team Memory backend is running (default: `http://localhost:3456`). The easiest way is the pre-built Docker image — see **[Docker self-host](#docker-self-host)** below.
 2. The MCP server package is built: `cd packages/mcp-server && npm install && npm run build`
 3. **Node.js 22** — the `command` in your MCP config must use the same Node version that built `better-sqlite3`. If you have multiple Node versions (e.g., nvm), use an absolute path to avoid ABI mismatch crashes. Or skip this entire class of problem by running the backend via the Docker image below.
+4. **Source-checkout self-deploy only (skip if using Docker):** after every `git pull` on `main`, rebuild the backend before minting keys: `npm run build --workspace=packages/backend`. A stale `dist/cli.js` from before a flag-schema change can silently reject or ignore new flags — for example, pre-#55 builds accept `--projects` but drop it without warning, producing unscoped keys. This step is unnecessary when running the Docker image, which ships a pre-built CLI.
 
 ## Docker self-host
 
@@ -63,10 +64,10 @@ The image honors the same env vars as a local `node` process. Override any of th
 
 ### API keys inside Docker
 
-The backend CLI (`npm run keys create <owner>`) works the same way inside the container:
+The backend CLI (`npm run keys create <owner> --projects <names>`) works the same way inside the container. The `create` and `update-key` subcommands require an explicit scope flag — pass `--projects alpha,beta` to scope the key, or `--unscoped` to mint a key with no project restriction:
 
 ```bash
-docker exec -it team-memory node packages/backend/dist/cli.js create my-agent-name
+docker exec -it team-memory node packages/backend/dist/cli.js create my-agent-name --projects hackathon
 ```
 
 Copy the printed `tm_...` key into `TEAM_MEMORY_API_KEY` in your MCP config.

--- a/e2e/scripts/reuse-loop.ts
+++ b/e2e/scripts/reuse-loop.ts
@@ -151,7 +151,7 @@ async function run(): Promise<void> {
 
     await waitForHealth(15_000);
 
-    const keyOut = spawnSync("npx", ["tsx", "src/cli.ts", "create", "e2e-reuse-loop"], {
+    const keyOut = spawnSync("npx", ["tsx", "src/cli.ts", "create", "e2e-reuse-loop", "--unscoped"], {
       cwd: BACKEND_DIR,
       env,
       encoding: "utf8",

--- a/packages/backend/src/cli.ts
+++ b/packages/backend/src/cli.ts
@@ -3,25 +3,51 @@ import { closeDb, getDb } from "./db.js";
 
 function usage(): never {
   console.error(`Usage:
-  npm run keys -- create <owner> [--projects alpha,beta]
+  npm run keys -- create <owner> (--projects alpha,beta | --unscoped)
   npm run keys -- list
-  npm run keys -- update-key <api_key> --projects alpha,beta
-  npm run keys -- revoke <api_key>`);
+  npm run keys -- update-key <api_key> (--projects alpha,beta | --unscoped)
+  npm run keys -- revoke <api_key>
+
+Scope flags are required on create/update-key — silently minting an unscoped key is not allowed.
+Pass explicit project names with --projects, or --unscoped to opt out of namespacing.`);
   process.exit(1);
 }
 
-function parseProjectsArg(value: string | undefined): string[] | null {
-  if (value === undefined) usage();
-  if (value === "" || value === "*") return null;
+function fail(message: string): never {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
 
-  const projects = Array.from(new Set(
-    value
-      .split(",")
-      .map((project) => project.trim())
-      .filter(Boolean),
+type ScopeFlags = { projects: string[] | null };
+
+function parseProjectsList(raw: string | undefined): string[] {
+  if (raw === undefined) fail("--projects requires a value, e.g. --projects alpha,beta");
+  const list = Array.from(new Set(
+    raw.split(",").map((project) => project.trim()).filter(Boolean),
   ));
+  if (list.length === 0) {
+    fail("--projects value is empty after parsing — pass at least one project name, or use --unscoped");
+  }
+  if (list.some((p) => p === "*")) {
+    fail("--projects does not accept '*' — use --unscoped to opt out of project scoping");
+  }
+  return list;
+}
 
-  return projects.length > 0 ? projects : null;
+function parseScopeFlags(args: string[]): ScopeFlags {
+  const projectsIdx = args.indexOf("--projects");
+  const unscopedIdx = args.indexOf("--unscoped");
+  const hasProjects = projectsIdx >= 0;
+  const hasUnscoped = unscopedIdx >= 0;
+
+  if (hasProjects && hasUnscoped) {
+    fail("--projects and --unscoped are mutually exclusive — pick exactly one");
+  }
+  if (!hasProjects && !hasUnscoped) {
+    fail("scope is required — pass --projects <names> or --unscoped");
+  }
+  if (hasUnscoped) return { projects: null };
+  return { projects: parseProjectsList(args[projectsIdx + 1]) };
 }
 
 function encodeProjects(projects: string[] | null): string | null {
@@ -120,8 +146,7 @@ try {
   switch (command) {
     case "create": {
       if (!firstArg) usage();
-      const flagIndex = rest.indexOf("--projects");
-      const projects = flagIndex >= 0 ? parseProjectsArg(rest[flagIndex + 1]) : null;
+      const { projects } = parseScopeFlags(rest);
       createKey(firstArg, projects);
       break;
     }
@@ -130,9 +155,8 @@ try {
       break;
     case "update-key": {
       if (!firstArg) usage();
-      const flagIndex = rest.indexOf("--projects");
-      if (flagIndex < 0) usage();
-      updateKeyProjects(firstArg, parseProjectsArg(rest[flagIndex + 1]));
+      const { projects } = parseScopeFlags(rest);
+      updateKeyProjects(firstArg, projects);
       break;
     }
     case "revoke":


### PR DESCRIPTION
## Summary

Closes the silent-unscoped-key class of bug at the CLI layer by making scope flags required on `keys create` and `keys update-key`. Stacks the self-deploy rebuild reminder from `docs-usability` into a single PR per Spike `4fe1d965` / Faye `c42dabf6` guidance.

- **CLI fail-loud**: `create` / `update-key` now require exactly one of `--projects <names>` or `--unscoped`. Missing → error. Empty / `*` value → error pointing to `--unscoped`. Both flags → error. No flag → error.
- **Docs one-hop**: `docs/mcp-config-template.md` gets a fourth prerequisite (source-checkout self-deploys rebuild after every `git pull`), kept as a self-contained step rather than inlined in quickstart.
- **Backward-breaking for one specific pattern**: callers that previously relied on `create <owner>` (no flag), `--projects ""`, or `--projects "*"` to mean "unscoped" must now pass `--unscoped` explicitly. That's the point — all three paths were silent scope-widening.

## Why

Pilot deploy on 2026-04-17 hit a silent-unscoped gotcha: a stale pre-#55 `dist/cli.js` in the source checkout dropped the `--projects hackathon` flag without warning, minting six unscoped keys. Detected only on post-mint verification via `/api/tasks/start`. Root cause was stale `dist`, but the true fix level is CLI-layer fail-loud, because the silent-widen path could also be hit by operator forgetfulness on a fresh install. Spike's principle #2 (no-silent-redefine) applies even more strongly here — silent scope widening deletes a security boundary rather than redefining a field.

## Smoke matrix (all pass)

| Command | Result |
|---|---|
| `create smoke` | ❌ `scope is required — pass --projects <names> or --unscoped` |
| `create smoke --projects` | ❌ `--projects requires a value, e.g. --projects alpha,beta` |
| `create smoke --projects ""` | ❌ `--projects value is empty after parsing …` |
| `create smoke --projects "*"` | ❌ `--projects does not accept '*' — use --unscoped` |
| `create smoke --projects alpha --unscoped` | ❌ `--projects and --unscoped are mutually exclusive` |
| `create smoke --unscoped` | ✅ `scope=*` |
| `create smoke --projects alpha,beta` | ✅ `scope=alpha,beta` |

## Test plan

- [x] `npm run build --workspace=packages/backend` compiles clean
- [x] Manual CLI matrix above (all 7 cases)
- [x] `gh run` CI green on this branch before self-merge
- [x] Pilot keys minted pre-change still work (they were minted with explicit `--projects hackathon`, unaffected)

## Authorization

Self-merge on CI green per Faye `c42dabf6` (revision of `23e32126`): stacked PR > sequenced, `(2) > (1)` priority, CLI flag-schema change is surface-level / non-architectural, Spike declined primary review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)