### PR TITLE
Add admin key provisioning endpoints

### DIFF
--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -2,6 +2,16 @@
 
 This document defines how agents should interact with Team Memory in their daily workflows. The goal is simple: **no agent should redo work that another agent already published**.
 
+## Programmatic Key Provisioning
+
+If you are wiring Team Memory into an orchestrator, CI job, or launcher, prefer the admin REST primitive (`POST /api/admin/keys`) over shelling into the backend host. The route is framework-neutral, returns the secret once, and carries the same scoped-by-default safety semantics we want from the CLI:
+
+- pass `default_projects: string[]` for a scoped key
+- use `unscoped: true` only when you deliberately want no default namespace
+- do **not** use `[]` / `"*"` / omitted scope as an unscoped proxy
+
+The full request / response contract lives in [`api.md`](api.md#admin-key-management). This document only covers how agents should use already-issued keys during real work.
+
 ## How Team Memory Measures Reuse
 
 Every interaction with a knowledge item is recorded so we can tell whether the system is actually saving work. The model has **four first-class tracked interactions** — learn these names, they show up in tool descriptions, reports, and the dashboard.

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@ For recommended agent workflows (when to publish, when to call `reuse_feedback`,
 
 ## Authentication
 
-The backend uses a simple Bearer token model. Tokens are minted with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner> --projects alpha,beta`) and identify an owner plus an explicit scope posture: either a default-project namespace (`default_projects`: a non-empty `string[]`) when minted with `--projects <names>`, or no project restriction (`default_projects` is `null`) when minted with `--unscoped`. The `create` and `update-key` subcommands require one of those two flags; there is no silent default.
+The backend uses a simple Bearer token model. Agent keys are minted either with the admin CLI (`npm run keys --workspace=packages/backend -- create <owner> (--projects alpha,beta | --unscoped)`) or programmatically via `POST /api/admin/keys` when `TEAM_MEMORY_ADMIN_KEY` is enabled. Each key identifies an owner plus an explicit scope posture: either a default-project namespace (`default_projects`: a non-empty `string[]`) when minted with `--projects <names>` / `default_projects`, or no project restriction (`default_projects` is `null`) when minted with `--unscoped` / `unscoped: true`. The CLI `create` and `update-key` subcommands require one of those two scope flags; there is no silent default.
 
 Three auth postures show up below:
 
@@ -34,6 +34,159 @@ Header format:
 ```
 Authorization: Bearer <api_key>
 ```
+
+---
+
+## Admin key management
+
+The `/api/admin/*` surface is a framework-neutral provisioning primitive for orchestrators, launchers, and CI that need to mint or revoke Team Memory API keys without shelling into the backend host.
+
+Admin routes are **dark by default**:
+
+- If `TEAM_MEMORY_ADMIN_KEY` is unset, all `/api/admin/*` routes return `404`.
+- If the admin bearer token is missing or wrong, all `/api/admin/*` routes also return `404`.
+- This is intentional: the admin surface does not advertise its existence to unauthenticated probing.
+
+Admin header format:
+
+```http
+Authorization: Bearer <TEAM_MEMORY_ADMIN_KEY>
+```
+
+### `POST /api/admin/keys`
+
+Mint a new API key. **Admin auth required.**
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `owner` | string | yes | Non-empty string. Becomes the owner attached to writes and observability rows. |
+| `default_projects` | string[] | conditional | Required unless `unscoped` is `true`. Must be a non-empty array of non-empty strings. `[]` and `["*"]` are invalid — use `unscoped: true` for an explicit opt-out. |
+| `unscoped` | boolean | conditional | Must be `true` when you want no default-project restriction. Cannot be combined with `default_projects`. |
+| `description` | string | no | Optional operator note. Blank strings normalize to `null`. |
+| `expires_at` | string | no | Optional ISO-8601 timestamp. Past timestamps are accepted; the key simply expires immediately. |
+
+**Scoped request example**
+
+```json
+{
+  "owner": "release-bot",
+  "default_projects": ["hackathon"],
+  "description": "pilot key for release automation",
+  "expires_at": "2026-04-24T23:59:59Z"
+}
+```
+
+**Explicit unscoped request example**
+
+```json
+{
+  "owner": "release-bot",
+  "unscoped": true,
+  "description": "cross-project break-glass key"
+}
+```
+
+**Response — 201**
+
+```json
+{
+  "id": "key_abc123",
+  "key": "tm_xxxxxxxxxxxxxxxxxxxxxxxx",
+  "owner": "release-bot",
+  "default_projects": ["hackathon"],
+  "unscoped": false,
+  "description": "pilot key for release automation",
+  "created_at": "2026-04-17T19:00:00.000Z",
+  "expires_at": "2026-04-24T23:59:59.000Z",
+  "last_used_at": null,
+  "revoked_at": null
+}
+```
+
+`key` is returned **once** at creation time. Later list/update endpoints never echo the secret back.
+
+**Errors**
+
+| Status | Code / shape | Condition |
+|---|---|---|
+| 400 | `admin_owner_required` | `owner` omitted |
+| 400 | `admin_owner_invalid` | `owner` not a non-empty string |
+| 400 | `admin_default_projects_required` | neither `default_projects` nor `unscoped: true` provided |
+| 400 | `admin_default_projects_invalid` | `default_projects` is not a non-empty string array |
+| 400 | `admin_unscoped_invalid` | `unscoped` provided but not boolean |
+| 400 | `admin_scope_conflict` | `default_projects` combined with `unscoped: true` |
+| 400 | `admin_description_invalid` | `description` provided but not string/null |
+| 400 | `admin_expires_at_invalid` | `expires_at` provided but not ISO-8601 |
+| 404 | `{ "error": "Not found" }` | `TEAM_MEMORY_ADMIN_KEY` unset, missing admin bearer, or wrong admin bearer |
+
+### `GET /api/admin/keys`
+
+List minted API keys. **Admin auth required.**
+
+**Response — 200**
+
+```json
+{
+  "items": [
+    {
+      "id": "key_abc123",
+      "owner": "release-bot",
+      "default_projects": ["hackathon"],
+      "unscoped": false,
+      "description": "pilot key for release automation",
+      "created_at": "2026-04-17T19:00:00.000Z",
+      "expires_at": "2026-04-24T23:59:59.000Z",
+      "last_used_at": "2026-04-17T19:10:00.000Z",
+      "revoked_at": null
+    }
+  ]
+}
+```
+
+The secret `key` field is intentionally omitted.
+
+### `PATCH /api/admin/keys/:id`
+
+Update a key's scope metadata. **Admin auth required.**
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `default_projects` | string[] | conditional | Same validation as `POST`. |
+| `unscoped` | boolean | conditional | Same validation as `POST`. |
+| `description` | string or `null` | no | Set to `null` to clear. |
+| `expires_at` | string or `null` | no | Set to `null` to clear. |
+
+At least one field must be provided. Scope updates use the same contract as `POST`: either a non-empty `default_projects` array or explicit `unscoped: true`.
+
+**Response — 200** — same shape as a `GET` list item.
+
+**Errors**
+
+| Status | Code / shape | Condition |
+|---|---|---|
+| 400 | `admin_update_empty` | No updatable fields provided |
+| 400 | `admin_*` validation codes above | Invalid scope / description / expiry fields |
+| 404 | `admin_key_not_found` | Unknown key id or already revoked |
+| 404 | `{ "error": "Not found" }` | Admin auth disabled or wrong admin bearer |
+
+### `DELETE /api/admin/keys/:id`
+
+Revoke a key. **Admin auth required.**
+
+**Response — 204**
+
+No body.
+
+**Errors**
+
+| Status | Code / shape | Condition |
+|---|---|---|
+| 404 | `admin_key_not_found` | Unknown key id or already revoked |
+| 404 | `{ "error": "Not found" }` | Admin auth disabled or wrong admin bearer |
 
 ---
 
@@ -421,12 +574,22 @@ Team-wide reuse snapshot. No auth.
 
 ## Error code catalog
 
-Task-session and task-trace endpoints return `{ error, code }` with a stable `code`. The full set:
+Task-session, task-trace, and admin-key endpoints return `{ error, code }` with a stable `code`. The full set:
 
 | Code | Status | Surface |
 |---|---|---|
 | `auth_missing` | 401 | Any auth-required endpoint (`PATCH /knowledge/:id`, `POST /knowledge/:id/feedback`, `POST /tasks/start`, `POST /tasks/:id/end`) or any optional-auth endpoint with `task_id` passthrough when the caller omits the Authorization header |
 | `auth_invalid` | 401 | Same surfaces — Authorization header present, but the bearer token does not match an active API key |
+| `admin_owner_required` | 400 | `POST /admin/keys` |
+| `admin_owner_invalid` | 400 | `POST /admin/keys` |
+| `admin_default_projects_required` | 400 | `POST /admin/keys`, `PATCH /admin/keys/:id` |
+| `admin_default_projects_invalid` | 400 | `POST /admin/keys`, `PATCH /admin/keys/:id` |
+| `admin_unscoped_invalid` | 400 | `POST /admin/keys`, `PATCH /admin/keys/:id` |
+| `admin_scope_conflict` | 400 | `POST /admin/keys`, `PATCH /admin/keys/:id` |
+| `admin_description_invalid` | 400 | `POST /admin/keys`, `PATCH /admin/keys/:id` |
+| `admin_expires_at_invalid` | 400 | `POST /admin/keys`, `PATCH /admin/keys/:id` |
+| `admin_update_empty` | 400 | `PATCH /admin/keys/:id` |
+| `admin_key_not_found` | 404 | `PATCH /admin/keys/:id`, `DELETE /admin/keys/:id` |
 | `task_description_required` | 400 | `POST /tasks/start` |
 | `task_description_invalid` | 400 | `POST /tasks/start` |
 | `task_project_invalid` | 400 | `POST /tasks/start` |
@@ -438,7 +601,7 @@ Task-session and task-trace endpoints return `{ error, code }` with a stable `co
 | `task_already_closed` | 409 | `POST /tasks/:id/end` |
 | `task_publish_failed` | 400 | `POST /tasks/:id/end` (partial-publish body) |
 
-Legacy endpoints (`/knowledge/*` without task-session semantics) return `{ error }` without a `code`. New error surfaces added after A1 should follow the `{ error, code }` pattern.
+Legacy endpoints (`/knowledge/*` without task-session semantics) return `{ error }` without a `code`. The admin-auth dark surface intentionally returns bare `404` (no `code`) when `TEAM_MEMORY_ADMIN_KEY` is unset or the admin bearer is missing/wrong; once a caller is on the authenticated admin path, validation and lookup failures use `{ error, code }`.
 
 ---
 

--- a/docs/mcp-config-template.md
+++ b/docs/mcp-config-template.md
@@ -72,6 +72,8 @@ docker exec -it team-memory node packages/backend/dist/cli.js create my-agent-na
 
 Copy the printed `tm_...` key into `TEAM_MEMORY_API_KEY` in your MCP config.
 
+If you are provisioning keys from another service instead of shelling into the container, enable `TEAM_MEMORY_ADMIN_KEY` on the backend and call `POST /api/admin/keys` directly. Scoped keys must pass `default_projects: string[]`; the only unscoped opt-out is `unscoped: true`. See [`api.md`](api.md#admin-key-management) for the exact wire contract.
+
 ## Claude Code (claude_desktop_config.json)
 
 Add this entry to your `mcpServers` configuration:

--- a/packages/backend/src/api-keys.ts
+++ b/packages/backend/src/api-keys.ts
@@ -1,0 +1,219 @@
+import { randomBytes } from "node:crypto";
+import type Database from "better-sqlite3";
+
+export interface ApiKeyRow {
+  id: string;
+  key: string;
+  owner: string;
+  default_projects: string | null;
+  description: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export interface ApiKeyRecord {
+  id: string;
+  key: string;
+  owner: string;
+  default_projects: string[] | null;
+  description: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export interface CreateApiKeyInput {
+  owner: string;
+  defaultProjects: string[] | null;
+  description?: string | null;
+  expiresAt?: string | null;
+}
+
+export interface UpdateApiKeyInput {
+  defaultProjects?: string[] | null;
+  description?: string | null;
+  expiresAt?: string | null;
+}
+
+export function parseStoredProjects(raw: string | null | undefined): string[] | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    const projects = normalizeProjectList(
+      parsed.filter((value): value is string => typeof value === "string"),
+    );
+    return projects;
+  } catch {
+    return null;
+  }
+}
+
+export function encodeProjects(projects: string[] | null): string | null {
+  return projects ? JSON.stringify(projects) : null;
+}
+
+export function normalizeProjectList(projects: string[] | null | undefined): string[] | null {
+  if (!projects) return null;
+
+  const normalized = Array.from(new Set(
+    projects
+      .map((project) => project.trim())
+      .filter(Boolean),
+  ));
+
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function parseProjectsArg(value: string | undefined): string[] {
+  if (value === undefined) {
+    throw new Error("--projects requires a value, e.g. --projects alpha,beta");
+  }
+
+  const normalized = normalizeProjectList(value.split(","));
+  if (!normalized) {
+    throw new Error("--projects value is empty after parsing — pass at least one project name, or use --unscoped");
+  }
+  if (normalized.some((project) => project === "*")) {
+    throw new Error("--projects does not accept '*' — use --unscoped to opt out of project scoping");
+  }
+
+  return normalized;
+}
+
+export function formatScope(rawProjects: string | null): string {
+  const projects = parseStoredProjects(rawProjects);
+  return projects ? projects.join(",") : "*";
+}
+
+export function createAdminKeySecret(): string {
+  return `tm_admin_${randomBytes(24).toString("hex")}`;
+}
+
+function createApiKeyId(): string {
+  return `key_${randomBytes(8).toString("hex")}`;
+}
+
+function createApiKeySecret(): string {
+  return `tm_${randomBytes(24).toString("hex")}`;
+}
+
+export function rowToApiKeyRecord(row: ApiKeyRow): ApiKeyRecord {
+  return {
+    id: row.id,
+    key: row.key,
+    owner: row.owner,
+    default_projects: parseStoredProjects(row.default_projects),
+    description: row.description,
+    expires_at: row.expires_at,
+    last_used_at: row.last_used_at,
+    created_at: row.created_at,
+    revoked_at: row.revoked_at,
+  };
+}
+
+export function createApiKey(
+  db: Database.Database,
+  input: CreateApiKeyInput,
+): ApiKeyRecord {
+  const record: ApiKeyRecord = {
+    id: createApiKeyId(),
+    key: createApiKeySecret(),
+    owner: input.owner,
+    default_projects: normalizeProjectList(input.defaultProjects),
+    description: input.description ?? null,
+    expires_at: input.expiresAt ?? null,
+    last_used_at: null,
+    created_at: new Date().toISOString(),
+    revoked_at: null,
+  };
+
+  db.prepare(
+    `INSERT INTO api_keys (
+      id, key, owner, default_projects, description, expires_at, last_used_at, created_at, revoked_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    record.id,
+    record.key,
+    record.owner,
+    encodeProjects(record.default_projects),
+    record.description,
+    record.expires_at,
+    record.last_used_at,
+    record.created_at,
+    record.revoked_at,
+  );
+
+  return record;
+}
+
+export function listApiKeys(db: Database.Database): ApiKeyRecord[] {
+  const rows = db
+    .prepare(
+      `SELECT id, key, owner, default_projects, description, expires_at, last_used_at, created_at, revoked_at
+       FROM api_keys
+       ORDER BY created_at DESC`,
+    )
+    .all() as ApiKeyRow[];
+
+  return rows.map(rowToApiKeyRecord);
+}
+
+export function getApiKeyById(db: Database.Database, id: string): ApiKeyRecord | null {
+  const row = db
+    .prepare(
+      `SELECT id, key, owner, default_projects, description, expires_at, last_used_at, created_at, revoked_at
+       FROM api_keys
+       WHERE id = ?`,
+    )
+    .get(id) as ApiKeyRow | undefined;
+
+  return row ? rowToApiKeyRecord(row) : null;
+}
+
+export function updateApiKeyById(
+  db: Database.Database,
+  id: string,
+  input: UpdateApiKeyInput,
+): ApiKeyRecord | null {
+  const sets: string[] = [];
+  const params: Array<string | null> = [];
+
+  if ("defaultProjects" in input) {
+    sets.push("default_projects = ?");
+    params.push(encodeProjects(normalizeProjectList(input.defaultProjects)));
+  }
+  if ("description" in input) {
+    sets.push("description = ?");
+    params.push(input.description ?? null);
+  }
+  if ("expiresAt" in input) {
+    sets.push("expires_at = ?");
+    params.push(input.expiresAt ?? null);
+  }
+
+  if (sets.length === 0) {
+    return getApiKeyById(db, id);
+  }
+
+  params.push(id);
+  const result = db
+    .prepare(`UPDATE api_keys SET ${sets.join(", ")} WHERE id = ? AND revoked_at IS NULL`)
+    .run(...params);
+
+  if (result.changes === 0) return null;
+  return getApiKeyById(db, id);
+}
+
+export function revokeApiKeyById(db: Database.Database, id: string): boolean {
+  const revokedAt = new Date().toISOString();
+  const result = db
+    .prepare("UPDATE api_keys SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL")
+    .run(revokedAt, id);
+
+  return result.changes > 0;
+}

--- a/packages/backend/src/auth.ts
+++ b/packages/backend/src/auth.ts
@@ -1,5 +1,6 @@
 import type { Context } from "hono";
 import { getDb } from "./db.js";
+import { parseStoredProjects } from "./api-keys.js";
 
 export interface ApiAuth {
   key: string;
@@ -8,13 +9,19 @@ export interface ApiAuth {
 }
 
 interface ApiKeyRow {
+  id: string | null;
   key: string;
   owner: string;
   default_projects: string | null;
+  expires_at: string | null;
 }
 
 function jsonError(c: Context, status: 401 | 403, error: string, code: string): Response {
   return c.json({ error, code }, status);
+}
+
+function notFound(c: Context): Response {
+  return c.json({ error: "Not found" }, 404);
 }
 
 function extractBearerToken(header: string | undefined): string | null {
@@ -23,36 +30,26 @@ function extractBearerToken(header: string | undefined): string | null {
   return match?.[1]?.trim() || null;
 }
 
-function parseDefaultProjects(raw: string | null | undefined): string[] | null {
-  if (!raw) return null;
-
-  try {
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return null;
-    const projects = Array.from(new Set(
-      parsed
-        .filter((value): value is string => typeof value === "string")
-        .map((value) => value.trim())
-        .filter(Boolean),
-    ));
-    return projects.length > 0 ? projects : null;
-  } catch {
-    return null;
-  }
-}
-
 function lookupApiAuth(token: string): ApiAuth | undefined {
   const db = getDb();
   const row = db
-    .prepare("SELECT key, owner, default_projects FROM api_keys WHERE key = ? AND revoked_at IS NULL")
+    .prepare("SELECT id, key, owner, default_projects, expires_at FROM api_keys WHERE key = ? AND revoked_at IS NULL")
     .get(token) as ApiKeyRow | undefined;
 
   if (!row) return undefined;
+  if (row.expires_at && Date.parse(row.expires_at) <= Date.now()) return undefined;
+
+  if (row.id) {
+    db.prepare("UPDATE api_keys SET last_used_at = ? WHERE id = ?").run(
+      new Date().toISOString(),
+      row.id,
+    );
+  }
 
   return {
     key: row.key,
     owner: row.owner,
-    defaultProjects: parseDefaultProjects(row.default_projects),
+    defaultProjects: parseStoredProjects(row.default_projects),
   };
 }
 
@@ -96,4 +93,18 @@ export function requireOwnerAccess(c: Context, itemOwner: string): ApiAuth | Res
     return jsonError(c, 403, "Only the owner can modify this item", "owner_forbidden");
   }
   return auth;
+}
+
+export function requireAdminAuth(c: Context): true | Response {
+  const adminKey = process.env.TEAM_MEMORY_ADMIN_KEY;
+  if (!adminKey) {
+    return notFound(c);
+  }
+
+  const token = extractBearerToken(c.req.header("authorization"));
+  if (!token || token !== adminKey) {
+    return notFound(c);
+  }
+
+  return true;
 }

--- a/packages/backend/src/cli.ts
+++ b/packages/backend/src/cli.ts
@@ -1,9 +1,17 @@
-import { randomBytes } from "node:crypto";
 import { closeDb, getDb } from "./db.js";
+import {
+  createAdminKeySecret,
+  createApiKey,
+  listApiKeys,
+  parseProjectsArg,
+  updateApiKeyById,
+  revokeApiKeyById,
+} from "./api-keys.js";
 
 function usage(): never {
   console.error(`Usage:
   npm run keys -- create <owner> (--projects alpha,beta | --unscoped)
+  npm run keys -- admin-init
   npm run keys -- list
   npm run keys -- update-key <api_key> (--projects alpha,beta | --unscoped)
   npm run keys -- revoke <api_key>
@@ -20,20 +28,6 @@ function fail(message: string): never {
 
 type ScopeFlags = { projects: string[] | null };
 
-function parseProjectsList(raw: string | undefined): string[] {
-  if (raw === undefined) fail("--projects requires a value, e.g. --projects alpha,beta");
-  const list = Array.from(new Set(
-    raw.split(",").map((project) => project.trim()).filter(Boolean),
-  ));
-  if (list.length === 0) {
-    fail("--projects value is empty after parsing — pass at least one project name, or use --unscoped");
-  }
-  if (list.some((p) => p === "*")) {
-    fail("--projects does not accept '*' — use --unscoped to opt out of project scoping");
-  }
-  return list;
-}
-
 function parseScopeFlags(args: string[]): ScopeFlags {
   const projectsIdx = args.indexOf("--projects");
   const unscopedIdx = args.indexOf("--unscoped");
@@ -47,55 +41,33 @@ function parseScopeFlags(args: string[]): ScopeFlags {
     fail("scope is required — pass --projects <names> or --unscoped");
   }
   if (hasUnscoped) return { projects: null };
-  return { projects: parseProjectsList(args[projectsIdx + 1]) };
-}
-
-function encodeProjects(projects: string[] | null): string | null {
-  return projects ? JSON.stringify(projects) : null;
-}
-
-function formatScope(projects: string | null): string {
-  if (!projects) return "*";
   try {
-    const parsed = JSON.parse(projects);
-    if (!Array.isArray(parsed) || parsed.length === 0) return "*";
-    return parsed.join(",");
-  } catch {
-    return projects;
+    return { projects: parseProjectsArg(args[projectsIdx + 1]) };
+  } catch (error) {
+    fail(error instanceof Error ? error.message : "invalid --projects value");
   }
 }
 
 function createKey(owner: string, projects: string[] | null): void {
   const db = getDb();
-  const key = `tm_${randomBytes(24).toString("hex")}`;
-  const createdAt = new Date().toISOString();
-
-  db.prepare(
-    "INSERT INTO api_keys (key, owner, default_projects, created_at, revoked_at) VALUES (?, ?, ?, ?, NULL)",
-  ).run(
-    key,
-    owner,
-    encodeProjects(projects),
-    createdAt,
-  );
+  const record = createApiKey(db, { owner, defaultProjects: projects });
 
   console.log(`Created API key for ${owner}`);
-  console.log(`key=${key}`);
-  console.log(`created_at=${createdAt}`);
-  console.log(`scope=${projects ? projects.join(",") : "*"}`);
+  console.log(`id=${record.id}`);
+  console.log(`key=${record.key}`);
+  console.log(`created_at=${record.created_at}`);
+  console.log(`scope=${record.default_projects ? record.default_projects.join(",") : "*"}`);
+}
+
+function initAdminKey(): void {
+  const key = createAdminKeySecret();
+  console.log("Generated TEAM_MEMORY_ADMIN_KEY");
+  console.log(`TEAM_MEMORY_ADMIN_KEY=${key}`);
 }
 
 function listKeys(): void {
   const db = getDb();
-  const rows = db
-    .prepare("SELECT key, owner, default_projects, created_at, revoked_at FROM api_keys ORDER BY created_at DESC")
-    .all() as Array<{
-      key: string;
-      owner: string;
-      default_projects: string | null;
-      created_at: string;
-      revoked_at: string | null;
-    }>;
+  const rows = listApiKeys(db);
 
   if (rows.length === 0) {
     console.log("No API keys found.");
@@ -104,21 +76,23 @@ function listKeys(): void {
 
   for (const row of rows) {
     console.log(
-      `${row.key} owner=${row.owner} scope=${formatScope(row.default_projects)} created_at=${row.created_at} status=${row.revoked_at ? "revoked" : "active"}`,
+      `${row.key} owner=${row.owner} scope=${row.default_projects ? row.default_projects.join(",") : "*"} created_at=${row.created_at} status=${row.revoked_at ? "revoked" : "active"}`,
     );
   }
 }
 
 function updateKeyProjects(key: string, projects: string[] | null): void {
   const db = getDb();
-  const result = db
-    .prepare("UPDATE api_keys SET default_projects = ? WHERE key = ? AND revoked_at IS NULL")
-    .run(encodeProjects(projects), key);
+  const row = db
+    .prepare("SELECT id FROM api_keys WHERE key = ? AND revoked_at IS NULL")
+    .get(key) as { id: string } | undefined;
 
-  if (result.changes === 0) {
+  if (!row) {
     console.error(`No active API key found for ${key}`);
     process.exit(1);
   }
+
+  updateApiKeyById(db, row.id, { defaultProjects: projects });
 
   console.log(`Updated API key ${key}`);
   console.log(`scope=${projects ? projects.join(",") : "*"}`);
@@ -126,12 +100,11 @@ function updateKeyProjects(key: string, projects: string[] | null): void {
 
 function revokeKey(key: string): void {
   const db = getDb();
-  const revokedAt = new Date().toISOString();
-  const result = db
-    .prepare("UPDATE api_keys SET revoked_at = ? WHERE key = ? AND revoked_at IS NULL")
-    .run(revokedAt, key);
+  const row = db
+    .prepare("SELECT id FROM api_keys WHERE key = ? AND revoked_at IS NULL")
+    .get(key) as { id: string } | undefined;
 
-  if (result.changes === 0) {
+  if (!row || !revokeApiKeyById(db, row.id)) {
     console.error(`No active API key found for ${key}`);
     process.exit(1);
   }
@@ -150,6 +123,9 @@ try {
       createKey(firstArg, projects);
       break;
     }
+    case "admin-init":
+      initAdminKey();
+      break;
     case "list":
       listKeys();
       break;

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -182,15 +182,21 @@ export function getDb(): Database.Database {
     END;
 
     CREATE TABLE IF NOT EXISTS api_keys (
+      id          TEXT UNIQUE,
       key         TEXT PRIMARY KEY,
       owner       TEXT NOT NULL,
       default_projects TEXT,
+      description TEXT,
+      expires_at  TEXT,
+      last_used_at TEXT,
       created_at  TEXT NOT NULL,
       revoked_at  TEXT
     );
 
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id);
     CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(owner);
     CREATE INDEX IF NOT EXISTS idx_api_keys_revoked_at ON api_keys(revoked_at);
+    CREATE INDEX IF NOT EXISTS idx_api_keys_expires_at ON api_keys(expires_at);
 
     CREATE TABLE IF NOT EXISTS tasks (
       task_id      TEXT PRIMARY KEY,
@@ -236,7 +242,14 @@ export function getDb(): Database.Database {
   ensureColumn(_db, "knowledge", "duplicate_of", "TEXT");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_knowledge_duplicate_of ON knowledge(duplicate_of)");
   ensureColumn(_db, "knowledge", "embedding", "BLOB");
+  ensureColumn(_db, "api_keys", "id", "TEXT");
   ensureColumn(_db, "api_keys", "default_projects", "TEXT");
+  ensureColumn(_db, "api_keys", "description", "TEXT");
+  ensureColumn(_db, "api_keys", "expires_at", "TEXT");
+  ensureColumn(_db, "api_keys", "last_used_at", "TEXT");
+  _db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id)");
+  _db.exec("CREATE INDEX IF NOT EXISTS idx_api_keys_expires_at ON api_keys(expires_at)");
+  _db.exec("UPDATE api_keys SET id = 'key_' || printf('%016x', rowid) WHERE id IS NULL OR id = ''");
   ensureColumn(_db, "reuse_feedback", "task_id", "TEXT REFERENCES tasks(task_id) ON DELETE SET NULL");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_reuse_feedback_task_id ON reuse_feedback(task_id)");
   cleanupFalsePositiveDuplicateOf(_db);

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -1,8 +1,16 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { v4 as uuidv4 } from "uuid";
-import { getOptionalApiAuth, requireApiAuth, requireOwnerAccess } from "./auth.js";
+import { getOptionalApiAuth, requireAdminAuth, requireApiAuth, requireOwnerAccess } from "./auth.js";
 import type { ApiAuth } from "./auth.js";
+import {
+  createApiKey,
+  listApiKeys,
+  normalizeProjectList,
+  revokeApiKeyById,
+  updateApiKeyById,
+} from "./api-keys.js";
+import type { ApiKeyRecord } from "./api-keys.js";
 import { getDb } from "./db.js";
 import { findPersistedDuplicateOf } from "./duplicates.js";
 import { embedKnowledgeItem, embedTexts } from "./embedding.js";
@@ -350,6 +358,118 @@ function jsonTaskError(
   return c.json({ error, code }, status);
 }
 
+function jsonAdminKeyError(
+  c: Context,
+  status: 400 | 404,
+  error: string,
+  code: string,
+): Response {
+  return c.json({ error, code }, status);
+}
+
+function hasOwn(body: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(body, key);
+}
+
+function serializeAdminKey(record: ApiKeyRecord, includeSecret = false) {
+  const payload = {
+    id: record.id,
+    owner: record.owner,
+    default_projects: record.default_projects,
+    unscoped: record.default_projects === null,
+    description: record.description,
+    created_at: record.created_at,
+    expires_at: record.expires_at,
+    last_used_at: record.last_used_at,
+    revoked_at: record.revoked_at,
+  };
+
+  return includeSecret
+    ? { ...payload, key: record.key }
+    : payload;
+}
+
+function normalizeAdminOwner(c: Context, value: unknown): string | Response {
+  if (value === undefined || value === null) {
+    return jsonAdminKeyError(c, 400, "owner is required", "admin_owner_required");
+  }
+  if (typeof value !== "string" || value.trim() === "") {
+    return jsonAdminKeyError(c, 400, "owner must be a non-empty string", "admin_owner_invalid");
+  }
+  return value.trim();
+}
+
+function normalizeAdminDescription(c: Context, value: unknown): string | null | Response {
+  if (value === null) return null;
+  if (typeof value !== "string") {
+    return jsonAdminKeyError(c, 400, "description must be a string when provided", "admin_description_invalid");
+  }
+  const normalized = value.trim();
+  return normalized === "" ? null : normalized;
+}
+
+function normalizeAdminExpiresAt(c: Context, value: unknown): string | null | Response {
+  if (value === null) return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    return jsonAdminKeyError(c, 400, "expires_at must be an ISO-8601 string when provided", "admin_expires_at_invalid");
+  }
+
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    return jsonAdminKeyError(c, 400, "expires_at must be an ISO-8601 string when provided", "admin_expires_at_invalid");
+  }
+
+  return new Date(parsed).toISOString();
+}
+
+function normalizeAdminProjects(c: Context, value: unknown): string[] | Response {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || item.trim() === "")) {
+    return jsonAdminKeyError(c, 400, "default_projects must be a non-empty array of non-empty strings", "admin_default_projects_invalid");
+  }
+
+  const normalized = normalizeProjectList(value);
+  if (!normalized || normalized.includes("*")) {
+    return jsonAdminKeyError(c, 400, "default_projects must be a non-empty array of non-empty strings", "admin_default_projects_invalid");
+  }
+
+  return normalized;
+}
+
+function normalizeAdminScopeInput(
+  c: Context,
+  body: Record<string, unknown>,
+  options: { requireScope: boolean },
+): { hasScopeChange: boolean; defaultProjects?: string[] | null } | Response {
+  const hasProjects = hasOwn(body, "default_projects");
+  const hasUnscoped = hasOwn(body, "unscoped");
+
+  if (!hasProjects && !hasUnscoped) {
+    if (options.requireScope) {
+      return jsonAdminKeyError(c, 400, "default_projects is required unless unscoped is true", "admin_default_projects_required");
+    }
+    return { hasScopeChange: false };
+  }
+
+  const unscoped = body.unscoped;
+  if (hasUnscoped && typeof unscoped !== "boolean") {
+    return jsonAdminKeyError(c, 400, "unscoped must be a boolean when provided", "admin_unscoped_invalid");
+  }
+  if (unscoped === true && hasProjects) {
+    return jsonAdminKeyError(c, 400, "default_projects cannot be combined with unscoped=true", "admin_scope_conflict");
+  }
+  if (unscoped === true) {
+    return { hasScopeChange: true, defaultProjects: null };
+  }
+  if (!hasProjects) {
+    return jsonAdminKeyError(c, 400, "default_projects is required unless unscoped is true", "admin_default_projects_required");
+  }
+
+  const defaultProjects = normalizeAdminProjects(c, body.default_projects);
+  if (defaultProjects instanceof Response) return defaultProjects;
+
+  return { hasScopeChange: true, defaultProjects };
+}
+
 function resolveScopedProjects(explicitProject: string | undefined, auth: ApiAuth | null): string[] | null {
   if (explicitProject === "*") return null;
   if (explicitProject !== undefined) return [explicitProject];
@@ -596,6 +716,99 @@ function recordViewEvent(
     ) VALUES (?, ?, 'view', NULL, ?, NULL, NULL, ?, NULL, ?)`,
   ).run(knowledgeId, owner, taskId, project, queryContext);
 }
+
+// 0. Admin key management
+api.post("/admin/keys", async (c) => {
+  const adminAuth = requireAdminAuth(c);
+  if (adminAuth instanceof Response) return adminAuth;
+
+  const body = await c.req.json() as Record<string, unknown>;
+  const owner = normalizeAdminOwner(c, body.owner);
+  if (owner instanceof Response) return owner;
+
+  const scope = normalizeAdminScopeInput(c, body, { requireScope: true });
+  if (scope instanceof Response) return scope;
+
+  const description = hasOwn(body, "description")
+    ? normalizeAdminDescription(c, body.description)
+    : null;
+  if (description instanceof Response) return description;
+
+  const expiresAt = hasOwn(body, "expires_at")
+    ? normalizeAdminExpiresAt(c, body.expires_at)
+    : null;
+  if (expiresAt instanceof Response) return expiresAt;
+
+  const record = createApiKey(getDb(), {
+    owner,
+    defaultProjects: scope.defaultProjects ?? null,
+    description,
+    expiresAt,
+  });
+
+  return c.json(serializeAdminKey(record, true), 201);
+});
+
+api.get("/admin/keys", (c) => {
+  const adminAuth = requireAdminAuth(c);
+  if (adminAuth instanceof Response) return adminAuth;
+
+  return c.json({
+    items: listApiKeys(getDb()).map((record) => serializeAdminKey(record)),
+  });
+});
+
+api.patch("/admin/keys/:id", async (c) => {
+  const adminAuth = requireAdminAuth(c);
+  if (adminAuth instanceof Response) return adminAuth;
+
+  const body = await c.req.json() as Record<string, unknown>;
+  const hasDescription = hasOwn(body, "description");
+  const hasExpiresAt = hasOwn(body, "expires_at");
+  const scope = normalizeAdminScopeInput(c, body, { requireScope: false });
+  if (scope instanceof Response) return scope;
+
+  if (!scope.hasScopeChange && !hasDescription && !hasExpiresAt) {
+    return jsonAdminKeyError(c, 400, "Provide at least one updatable field", "admin_update_empty");
+  }
+
+  let description: string | null | undefined;
+  if (hasDescription) {
+    const normalizedDescription = normalizeAdminDescription(c, body.description);
+    if (normalizedDescription instanceof Response) return normalizedDescription;
+    description = normalizedDescription;
+  }
+
+  let expiresAt: string | null | undefined;
+  if (hasExpiresAt) {
+    const normalizedExpiresAt = normalizeAdminExpiresAt(c, body.expires_at);
+    if (normalizedExpiresAt instanceof Response) return normalizedExpiresAt;
+    expiresAt = normalizedExpiresAt;
+  }
+
+  const updated = updateApiKeyById(getDb(), c.req.param("id"), {
+    ...(scope.hasScopeChange ? { defaultProjects: scope.defaultProjects ?? null } : {}),
+    ...(hasDescription ? { description } : {}),
+    ...(hasExpiresAt ? { expiresAt } : {}),
+  });
+
+  if (!updated) {
+    return jsonAdminKeyError(c, 404, "Admin key not found", "admin_key_not_found");
+  }
+
+  return c.json(serializeAdminKey(updated));
+});
+
+api.delete("/admin/keys/:id", (c) => {
+  const adminAuth = requireAdminAuth(c);
+  if (adminAuth instanceof Response) return adminAuth;
+
+  if (!revokeApiKeyById(getDb(), c.req.param("id"))) {
+    return jsonAdminKeyError(c, 404, "Admin key not found", "admin_key_not_found");
+  }
+
+  return new Response(null, { status: 204 });
+});
 
 // 1. POST /api/knowledge
 api.post("/knowledge", async (c) => {

--- a/packages/backend/tests/admin-keys.test.ts
+++ b/packages/backend/tests/admin-keys.test.ts
@@ -1,0 +1,356 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-admin-keys-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+let createStoredApiKey: typeof import("../src/api-keys.ts").createApiKey;
+
+function adminHeaders(key = process.env.TEAM_MEMORY_ADMIN_KEY ?? "tm_admin_test"): HeadersInit {
+  return {
+    authorization: `Bearer ${key}`,
+    "content-type": "application/json",
+  };
+}
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    claim: string;
+    project: string;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim,
+    null,
+    JSON.stringify(["tests/admin-keys.test.ts"]),
+    input.project,
+    "admin",
+    JSON.stringify(["admin"]),
+    "high",
+    "Recheck if admin key semantics change.",
+    "Seeder",
+    JSON.stringify([]),
+    null,
+    null,
+    null,
+    null,
+    now,
+    now,
+  );
+}
+
+before(async () => {
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+  const apiKeysModule = await import("../src/api-keys.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+  createStoredApiKey = apiKeysModule.createApiKey;
+});
+
+afterEach(() => {
+  delete process.env.TEAM_MEMORY_ADMIN_KEY;
+  const db = getDb();
+  db.exec("DELETE FROM task_publications; DELETE FROM reuse_feedback; DELETE FROM usage_events; DELETE FROM tasks; DELETE FROM knowledge; DELETE FROM api_keys;");
+});
+
+after(() => {
+  delete process.env.TEAM_MEMORY_DB;
+  delete process.env.TEAM_MEMORY_ADMIN_KEY;
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("POST /api/admin/keys returns 404 when admin auth is disabled", async () => {
+  const response = await app.request("http://localhost/api/admin/keys", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      owner: "DevOps",
+      default_projects: ["alpha"],
+    }),
+  });
+
+  assert.equal(response.status, 404);
+});
+
+test("POST /api/admin/keys returns 404 when the admin key is wrong or missing", async () => {
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+
+  const missingAuthResponse = await app.request("http://localhost/api/admin/keys", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      owner: "DevOps",
+      default_projects: ["alpha"],
+    }),
+  });
+  assert.equal(missingAuthResponse.status, 404);
+
+  const wrongAuthResponse = await app.request("http://localhost/api/admin/keys", {
+    method: "POST",
+    headers: adminHeaders("tm_admin_wrong"),
+    body: JSON.stringify({
+      owner: "DevOps",
+      default_projects: ["alpha"],
+    }),
+  });
+  assert.equal(wrongAuthResponse.status, 404);
+});
+
+test("POST /api/admin/keys mints a scoped key that is immediately usable", async () => {
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-item", claim: "Alpha note", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-item", claim: "Beta note", project: "beta" });
+
+  const response = await app.request("http://localhost/api/admin/keys", {
+    method: "POST",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      owner: "DevOps",
+      default_projects: ["alpha"],
+      description: "scoped alpha key",
+      expires_at: "2026-06-01T00:00:00Z",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  const body = await response.json() as {
+    id: string;
+    key: string;
+    owner: string;
+    default_projects: string[] | null;
+    unscoped: boolean;
+    description: string | null;
+    expires_at: string | null;
+  };
+  assert.equal(typeof body.id, "string");
+  assert.equal(typeof body.key, "string");
+  assert.equal(body.owner, "DevOps");
+  assert.deepEqual(body.default_projects, ["alpha"]);
+  assert.equal(body.unscoped, false);
+  assert.equal(body.description, "scoped alpha key");
+  assert.equal(body.expires_at, "2026-06-01T00:00:00.000Z");
+
+  const knowledgeResponse = await app.request("http://localhost/api/knowledge", {
+    headers: { authorization: `Bearer ${body.key}` },
+  });
+
+  assert.equal(knowledgeResponse.status, 200);
+  const knowledgeBody = await knowledgeResponse.json() as {
+    items: Array<{ id: string }>;
+    total: number;
+  };
+  assert.deepEqual(knowledgeBody.items.map((item) => item.id), ["alpha-item"]);
+  assert.equal(knowledgeBody.total, 1);
+});
+
+test("POST /api/admin/keys supports explicit unscoped opt-out", async () => {
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-item", claim: "Alpha note", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-item", claim: "Beta note", project: "beta" });
+
+  const response = await app.request("http://localhost/api/admin/keys", {
+    method: "POST",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      owner: "DevOps",
+      unscoped: true,
+      description: "explicit unscoped key",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  const body = await response.json() as {
+    key: string;
+    default_projects: string[] | null;
+    unscoped: boolean;
+  };
+  assert.equal(body.default_projects, null);
+  assert.equal(body.unscoped, true);
+
+  const knowledgeResponse = await app.request("http://localhost/api/knowledge", {
+    headers: { authorization: `Bearer ${body.key}` },
+  });
+
+  assert.equal(knowledgeResponse.status, 200);
+  const knowledgeBody = await knowledgeResponse.json() as {
+    items: Array<{ id: string }>;
+  };
+  assert.deepEqual(
+    knowledgeBody.items.map((item) => item.id).sort(),
+    ["alpha-item", "beta-item"],
+  );
+});
+
+test("POST /api/admin/keys rejects ambiguous or missing scope input", async () => {
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+
+  const cases = [
+    {
+      body: { owner: "DevOps" },
+      status: 400,
+      code: "admin_default_projects_required",
+    },
+    {
+      body: { owner: "DevOps", default_projects: [] },
+      status: 400,
+      code: "admin_default_projects_invalid",
+    },
+    {
+      body: { owner: "DevOps", default_projects: ["alpha"], unscoped: true },
+      status: 400,
+      code: "admin_scope_conflict",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const response = await app.request("http://localhost/api/admin/keys", {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify(testCase.body),
+    });
+
+    assert.equal(response.status, testCase.status);
+    const body = await response.json() as { code: string };
+    assert.equal(body.code, testCase.code);
+  }
+});
+
+test("GET /api/admin/keys lists keys without echoing secrets", async () => {
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+  await app.request("http://localhost/api/admin/keys", {
+    method: "POST",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      owner: "DevOps",
+      default_projects: ["alpha"],
+      description: "list test key",
+    }),
+  });
+
+  const response = await app.request("http://localhost/api/admin/keys", {
+    headers: { authorization: "Bearer tm_admin_secret" },
+  });
+
+  assert.equal(response.status, 200);
+  const body = await response.json() as {
+    items: Array<Record<string, unknown>>;
+  };
+
+  assert.equal(body.items.length, 1);
+  assert.equal("key" in body.items[0]!, false);
+  assert.deepEqual(body.items[0]!.default_projects, ["alpha"]);
+  assert.equal(body.items[0]!.unscoped, false);
+});
+
+test("PATCH /api/admin/keys can switch an existing key to explicit unscoped mode", async () => {
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+  const db = getDb();
+  insertKnowledgeRow(db, { id: "alpha-item", claim: "Alpha note", project: "alpha" });
+  insertKnowledgeRow(db, { id: "beta-item", claim: "Beta note", project: "beta" });
+
+  const createdResponse = await app.request("http://localhost/api/admin/keys", {
+    method: "POST",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      owner: "DevOps",
+      default_projects: ["alpha"],
+    }),
+  });
+  const createdBody = await createdResponse.json() as {
+    id: string;
+    key: string;
+  };
+
+  const patchResponse = await app.request(`http://localhost/api/admin/keys/${createdBody.id}`, {
+    method: "PATCH",
+    headers: adminHeaders(),
+    body: JSON.stringify({
+      unscoped: true,
+      description: "now unscoped",
+    }),
+  });
+
+  assert.equal(patchResponse.status, 200);
+  const patchBody = await patchResponse.json() as {
+    default_projects: string[] | null;
+    unscoped: boolean;
+    description: string | null;
+  };
+  assert.equal(patchBody.default_projects, null);
+  assert.equal(patchBody.unscoped, true);
+  assert.equal(patchBody.description, "now unscoped");
+
+  const knowledgeResponse = await app.request("http://localhost/api/knowledge", {
+    headers: { authorization: `Bearer ${createdBody.key}` },
+  });
+  const knowledgeBody = await knowledgeResponse.json() as {
+    items: Array<{ id: string }>;
+  };
+  assert.deepEqual(
+    knowledgeBody.items.map((item) => item.id).sort(),
+    ["alpha-item", "beta-item"],
+  );
+});
+
+test("DELETE /api/admin/keys revokes the key and expired keys return 401 on use", async () => {
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+  const activeRecord = createStoredApiKey(getDb(), {
+    owner: "DeleteMe",
+    defaultProjects: ["alpha"],
+  });
+  const expiredRecord = createStoredApiKey(getDb(), {
+    owner: "Expired",
+    defaultProjects: ["alpha"],
+    expiresAt: new Date(Date.now() - 60_000).toISOString(),
+  });
+
+  const deleteResponse = await app.request(`http://localhost/api/admin/keys/${activeRecord.id}`, {
+    method: "DELETE",
+    headers: { authorization: "Bearer tm_admin_secret" },
+  });
+  assert.equal(deleteResponse.status, 204);
+
+  const revokedUseResponse = await app.request("http://localhost/api/knowledge", {
+    headers: { authorization: `Bearer ${activeRecord.key}` },
+  });
+  assert.equal(revokedUseResponse.status, 401);
+  const revokedBody = await revokedUseResponse.json() as { code: string };
+  assert.equal(revokedBody.code, "auth_invalid");
+
+  const expiredUseResponse = await app.request("http://localhost/api/knowledge", {
+    headers: { authorization: `Bearer ${expiredRecord.key}` },
+  });
+  assert.equal(expiredUseResponse.status, 401);
+  const expiredBody = await expiredUseResponse.json() as { code: string };
+  assert.equal(expiredBody.code, "auth_invalid");
+});


### PR DESCRIPTION
## Summary
- add dark-admin `POST /api/admin/keys`, `GET /api/admin/keys`, `PATCH /api/admin/keys/:id`, and `DELETE /api/admin/keys/:id`
- add shared API-key helpers (`id`, `description`, `expires_at`, `last_used_at`) plus expiry-aware auth lookup
- document the new admin primitive in `docs/api.md`, `docs/agent-protocol.md`, and `docs/mcp-config-template.md`

## Locked A5 contract
- admin routes are enabled only when `TEAM_MEMORY_ADMIN_KEY` is set; otherwise `/api/admin/*` returns `404`
- key minting is scoped by default: callers must pass `default_projects: string[]` unless they explicitly opt out with `unscoped: true`
- `[]`, `"*"`, omitted scope, and mixed `default_projects + unscoped:true` are rejected instead of silently widening scope
- minted keys are returned once on create, never echoed by list/update

## Validation
- `npm run build --workspace=packages/backend`
- `node --test --import tsx packages/backend/tests/admin-keys.test.ts`
- `npm test --workspace=packages/backend`

Closes #45.
