### PR TITLE
Fix startup schema assertion for legacy api_keys DBs

### DIFF
--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -21,6 +21,19 @@ function hasColumn(db: Database.Database, table: string, column: string): boolea
   return rows.some((row) => row.name === column);
 }
 
+export function assertSchemaUpToDate(
+  db: Database.Database,
+  table: string,
+  requiredColumns: string[],
+): void {
+  const missing = requiredColumns.filter((column) => !hasColumn(db, table, column));
+  if (missing.length > 0) {
+    throw new Error(
+      `Schema mismatch for ${table}: missing columns ${missing.join(", ")}`,
+    );
+  }
+}
+
 function ensureColumn(db: Database.Database, table: string, column: string, definition: string): void {
   if (!hasColumn(db, table, column)) {
     db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
@@ -193,10 +206,8 @@ export function getDb(): Database.Database {
       revoked_at  TEXT
     );
 
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id);
     CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(owner);
     CREATE INDEX IF NOT EXISTS idx_api_keys_revoked_at ON api_keys(revoked_at);
-    CREATE INDEX IF NOT EXISTS idx_api_keys_expires_at ON api_keys(expires_at);
 
     CREATE TABLE IF NOT EXISTS tasks (
       task_id      TEXT PRIMARY KEY,
@@ -247,9 +258,10 @@ export function getDb(): Database.Database {
   ensureColumn(_db, "api_keys", "description", "TEXT");
   ensureColumn(_db, "api_keys", "expires_at", "TEXT");
   ensureColumn(_db, "api_keys", "last_used_at", "TEXT");
+  _db.exec("UPDATE api_keys SET id = 'key_' || printf('%016x', rowid) WHERE id IS NULL OR id = ''");
+  assertSchemaUpToDate(_db, "api_keys", ["key", "id", "default_projects", "expires_at"]);
   _db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id)");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_api_keys_expires_at ON api_keys(expires_at)");
-  _db.exec("UPDATE api_keys SET id = 'key_' || printf('%016x', rowid) WHERE id IS NULL OR id = ''");
   ensureColumn(_db, "reuse_feedback", "task_id", "TEXT REFERENCES tasks(task_id) ON DELETE SET NULL");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_reuse_feedback_task_id ON reuse_feedback(task_id)");
   cleanupFalsePositiveDuplicateOf(_db);

--- a/packages/backend/tests/task-sessions-schema.test.ts
+++ b/packages/backend/tests/task-sessions-schema.test.ts
@@ -15,6 +15,18 @@ interface TableColumnInfo {
   name: string;
 }
 
+interface ApiKeyRow {
+  id: string | null;
+  key: string;
+  owner: string;
+  default_projects: string | null;
+  description: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
 interface UsageEventRow {
   id: number;
   knowledge_id: string | null;
@@ -42,6 +54,7 @@ interface ReuseFeedbackRow {
 
 let getDb: () => Database.Database;
 let closeDb: () => void;
+let assertSchemaUpToDate: (db: Database.Database, table: string, columns: string[]) => void;
 
 function tableColumns(db: Database.Database, table: string): string[] {
   return (db.prepare(`PRAGMA table_info(${table})`).all() as TableColumnInfo[]).map((column) => column.name);
@@ -69,9 +82,12 @@ function resetDbFile(): void {
 }
 
 before(async () => {
-  const dbModule = await import("../src/db.ts");
+  const dbModule = await import("../src/db.ts") as typeof import("../src/db.ts") & {
+    assertSchemaUpToDate?: (db: Database.Database, table: string, columns: string[]) => void;
+  };
   getDb = dbModule.getDb;
   closeDb = dbModule.closeDb;
+  assertSchemaUpToDate = dbModule.assertSchemaUpToDate!;
 });
 
 afterEach(() => {
@@ -236,4 +252,77 @@ test("migrates legacy usage and feedback tables without losing rows", () => {
   assert.equal(feedbackRows[0]!.verdict, "useful");
   assert.equal(feedbackRows[0]!.comment, "Still relevant after migration.");
   assert.equal(feedbackRows[0]!.task_id, null);
+});
+
+test("migrates legacy api_keys schema before creating A5 indexes", () => {
+  const legacyDb = new Database(dbPath);
+  legacyDb.pragma("foreign_keys = ON");
+
+  legacyDb.exec(`
+    CREATE TABLE api_keys (
+      key         TEXT PRIMARY KEY,
+      owner       TEXT NOT NULL,
+      created_at  TEXT NOT NULL,
+      revoked_at  TEXT,
+      default_projects TEXT
+    );
+  `);
+
+  legacyDb.prepare(
+    `INSERT INTO api_keys (key, owner, created_at, revoked_at, default_projects)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    "tm_legacy_key",
+    "LegacyOwner",
+    "2026-04-17T00:00:00.000Z",
+    null,
+    JSON.stringify(["hackathon"]),
+  );
+
+  legacyDb.close();
+
+  const db = getDb();
+  const columns = tableColumns(db, "api_keys");
+  assert.ok(columns.includes("id"));
+  assert.ok(columns.includes("description"));
+  assert.ok(columns.includes("expires_at"));
+  assert.ok(columns.includes("last_used_at"));
+  assert.ok(indexExists(db, "idx_api_keys_id"));
+  assert.ok(indexExists(db, "idx_api_keys_expires_at"));
+
+  const row = db.prepare(
+    `SELECT id, key, owner, default_projects, description, expires_at, last_used_at, created_at, revoked_at
+     FROM api_keys
+     WHERE key = ?`,
+  ).get("tm_legacy_key") as ApiKeyRow | undefined;
+
+  assert.ok(row);
+  assert.equal(row!.owner, "LegacyOwner");
+  assert.equal(row!.default_projects, JSON.stringify(["hackathon"]));
+  assert.equal(row!.description, null);
+  assert.equal(row!.expires_at, null);
+  assert.equal(row!.last_used_at, null);
+  assert.match(row!.id ?? "", /^key_[0-9a-f]{16}$/);
+});
+
+test("assertSchemaUpToDate rejects stale api_keys schema before migration", () => {
+  const legacyDb = new Database(dbPath);
+  legacyDb.pragma("foreign_keys = ON");
+
+  legacyDb.exec(`
+    CREATE TABLE api_keys (
+      key         TEXT PRIMARY KEY,
+      owner       TEXT NOT NULL,
+      created_at  TEXT NOT NULL,
+      revoked_at  TEXT,
+      default_projects TEXT
+    );
+  `);
+
+  assert.throws(
+    () => assertSchemaUpToDate(legacyDb, "api_keys", ["key", "id", "default_projects", "expires_at"]),
+    /api_keys.*id.*expires_at|id.*expires_at.*api_keys/,
+  );
+
+  legacyDb.close();
 });


### PR DESCRIPTION
## Summary
- move A5-only `api_keys` index creation behind additive column migration and ID backfill
- add `assertSchemaUpToDate()` and fail fast on the A5-critical `api_keys` columns after migration
- cover the legacy-shared-DB path with schema tests, including the exact stale `api_keys` fixture shape

## Why this exists
Current `main@1efa41d` is not safe to cold-start against the legacy shared pilot DB. On that DB shape, startup hits:
- `CREATE UNIQUE INDEX ... ON api_keys(id)`
- `CREATE INDEX ... ON api_keys(expires_at)`

before `ensureColumn()` has added those columns, so the first authenticated request returns `500 no such column: id` and the migration path never runs.

This PR keeps the fix scoped to Spike's F4 boundary:
- IN: startup schema assertion on A5-critical columns (`key`, `id`, `default_projects`, `expires_at`)
- IN: stale-DB fixture test
- OUT: migration versioning, transactional migration rewrite, broader migration framework changes

## Validation
- `node --test --import tsx packages/backend/tests/task-sessions-schema.test.ts`
- `npm run build --workspace=packages/backend`
- `npm test --workspace=packages/backend`
- copied-shared-DB probe: current branch returns `401 auth_invalid` on first authenticated call instead of `500`, and the copied DB ends up with `id`, `description`, `expires_at`, `last_used_at`

## Review routing
- Primary: @umiri
- Architecture consult: @Spike

Refs #62
