### PR TITLE
feat(backend): add write-side audit log

### DIFF
--- a/packages/backend/src/auth.ts
+++ b/packages/backend/src/auth.ts
@@ -3,6 +3,7 @@ import { getDb } from "./db.js";
 import { parseStoredProjects } from "./api-keys.js";
 
 export interface ApiAuth {
+  id: string | null;
   key: string;
   owner: string;
   defaultProjects: string[] | null;
@@ -47,6 +48,7 @@ function lookupApiAuth(token: string): ApiAuth | undefined {
   }
 
   return {
+    id: row.id,
     key: row.key,
     owner: row.owner,
     defaultProjects: parseStoredProjects(row.default_projects),

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -77,6 +77,27 @@ function createUsageEventsIndexes(db: Database.Database): void {
   `);
 }
 
+function createAuditEventsTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS audit_events (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_type      TEXT NOT NULL CHECK (event_type IN ('publish', 'update', 'supersede', 'delete')),
+      knowledge_id    TEXT NOT NULL,
+      owner           TEXT NOT NULL,
+      project         TEXT,
+      actor_key_id    TEXT REFERENCES api_keys(id) ON DELETE SET NULL,
+      changed_fields  TEXT,
+      created_at      TEXT NOT NULL
+    );
+  `);
+}
+
+function createAuditEventsIndexes(db: Database.Database): void {
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_audit_events_created_at ON audit_events(created_at);
+  `);
+}
+
 function ensureUsageEventsSchema(db: Database.Database): void {
   createUsageEventsTable(db);
 
@@ -262,6 +283,8 @@ export function getDb(): Database.Database {
   assertSchemaUpToDate(_db, "api_keys", ["key", "id", "default_projects", "expires_at"]);
   _db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_id ON api_keys(id)");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_api_keys_expires_at ON api_keys(expires_at)");
+  createAuditEventsTable(_db);
+  createAuditEventsIndexes(_db);
   ensureColumn(_db, "reuse_feedback", "task_id", "TEXT REFERENCES tasks(task_id) ON DELETE SET NULL");
   _db.exec("CREATE INDEX IF NOT EXISTS idx_reuse_feedback_task_id ON reuse_feedback(task_id)");
   cleanupFalsePositiveDuplicateOf(_db);

--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -34,6 +34,7 @@ interface SemanticKnowledgeRow extends KnowledgeRow {
 type SearchMode = "fts" | "semantic" | "hybrid";
 type ReuseVerdict = "useful" | "not_useful" | "outdated";
 type TaskStatus = "open" | "completed" | "abandoned";
+type AuditEventType = "publish" | "update" | "supersede" | "delete";
 
 interface TaskRow {
   task_id: string;
@@ -43,6 +44,17 @@ interface TaskRow {
   status: TaskStatus;
   opened_at: string;
   closed_at: string | null;
+}
+
+interface AuditEventRow {
+  id: number;
+  event_type: AuditEventType;
+  knowledge_id: string;
+  owner: string;
+  project: string | null;
+  actor_key_id: string | null;
+  changed_fields: string | null;
+  created_at: string;
 }
 
 interface PublishKnowledgeInput {
@@ -78,6 +90,11 @@ interface PublishKnowledgeFailure {
 }
 
 type PublishKnowledgeResult = PublishKnowledgeSuccess | PublishKnowledgeFailure;
+
+interface PublishKnowledgeOptions {
+  taskId?: string;
+  actorKeyId?: string | null;
+}
 
 interface TrackedSearchItem {
   id: string;
@@ -122,6 +139,26 @@ function summaryFromRow(row: KnowledgeRow) {
     duplicate_of: row.duplicate_of, created_at: row.created_at,
     ...qualityFlagsFromRow(row),
   };
+}
+
+function auditEventToJson(row: AuditEventRow) {
+  return {
+    id: row.id,
+    event_type: row.event_type,
+    knowledge_id: row.knowledge_id,
+    owner: row.owner,
+    project: row.project,
+    actor_key_id: row.actor_key_id,
+    changed_fields: row.changed_fields ? JSON.parse(row.changed_fields) : null,
+    created_at: row.created_at,
+  };
+}
+
+function parseSinceDuration(value: string): string | null {
+  const match = /^(\d+)d$/.exec(value.trim());
+  if (!match) return null;
+  const days = Number.parseInt(match[1]!, 10);
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 }
 
 function parseTagList(tags: string | null | undefined): string[] | undefined {
@@ -176,6 +213,33 @@ function compareSearchResults(left: SearchResultItem & { hybrid_score: number },
     return modePriority[right.search_mode] - modePriority[left.search_mode];
   }
   return Date.parse(right.created_at) - Date.parse(left.created_at);
+}
+
+function recordAuditEvent(
+  db: ReturnType<typeof getDb>,
+  input: {
+    eventType: AuditEventType;
+    knowledgeId: string;
+    owner: string;
+    project: string | null;
+    actorKeyId?: string | null;
+    changedFields?: string[] | null;
+    createdAt?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO audit_events (
+      event_type, knowledge_id, owner, project, actor_key_id, changed_fields, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.eventType,
+    input.knowledgeId,
+    input.owner,
+    input.project,
+    input.actorKeyId ?? null,
+    input.changedFields ? JSON.stringify(input.changedFields) : null,
+    input.createdAt ?? new Date().toISOString(),
+  );
 }
 
 async function runSemanticCandidates(
@@ -531,7 +595,7 @@ async function publishKnowledgeItem(
   db: ReturnType<typeof getDb>,
   owner: string,
   body: PublishKnowledgeInput,
-  taskId?: string,
+  options: PublishKnowledgeOptions = {},
 ): Promise<PublishKnowledgeResult> {
   const missing: string[] = [];
   for (const field of ["claim", "source", "project", "tags", "confidence", "staleness_hint"] as const) {
@@ -573,13 +637,19 @@ async function publishKnowledgeItem(
     embedding,
   });
   const duplicateOf = findPersistedDuplicateOf(claim, project, duplicates);
+  let supersededProject: string | null = null;
 
   if (supersedes) {
-    const old = db.prepare("SELECT id, superseded_by FROM knowledge WHERE id = ?").get(supersedes) as { id: string; superseded_by: string | null } | undefined;
+    const old = db.prepare("SELECT id, project, superseded_by FROM knowledge WHERE id = ?").get(supersedes) as {
+      id: string;
+      project: string;
+      superseded_by: string | null;
+    } | undefined;
     if (!old) return { ok: false, status: 400, error: `Superseded item not found: ${supersedes}` };
     if (old.superseded_by) {
       return { ok: false, status: 400, error: `Item ${supersedes} is already superseded by ${old.superseded_by}` };
     }
+    supersededProject = old.project;
   }
 
   if (relatedTo && Array.isArray(relatedTo)) {
@@ -624,8 +694,26 @@ async function publishKnowledgeItem(
     if (supersedes) {
       updateSuperseded.run(id, supersedes);
     }
-    if (taskId) {
-      linkTaskPublication.run(taskId, id, now);
+    if (options.taskId) {
+      linkTaskPublication.run(options.taskId, id, now);
+    }
+    recordAuditEvent(db, {
+      eventType: "publish",
+      knowledgeId: id,
+      owner,
+      project,
+      actorKeyId: options.actorKeyId ?? null,
+      createdAt: now,
+    });
+    if (supersedes) {
+      recordAuditEvent(db, {
+        eventType: "supersede",
+        knowledgeId: supersedes,
+        owner,
+        project: supersededProject,
+        actorKeyId: options.actorKeyId ?? null,
+        createdAt: now,
+      });
     }
   })();
 
@@ -810,6 +898,89 @@ api.delete("/admin/keys/:id", (c) => {
   return new Response(null, { status: 204 });
 });
 
+api.get("/admin/audit-log", (c) => {
+  const adminAuth = requireAdminAuth(c);
+  if (adminAuth instanceof Response) return adminAuth;
+
+  const owner = c.req.query("owner");
+  const project = c.req.query("project");
+  const eventType = c.req.query("event_type");
+  const knowledgeId = c.req.query("knowledge_id");
+  const since = c.req.query("since");
+  const limitRaw = c.req.query("limit");
+  const offsetRaw = c.req.query("offset");
+
+  if (eventType && !["publish", "update", "supersede", "delete"].includes(eventType)) {
+    return c.json({ error: "event_type must be one of: publish, update, supersede, delete" }, 400);
+  }
+
+  let sinceCutoff: string | null = null;
+  if (since) {
+    sinceCutoff = parseSinceDuration(since);
+    if (!sinceCutoff) {
+      return c.json({ error: "since must be in Nd format, for example 7d or 30d" }, 400);
+    }
+  }
+
+  let limit = 100;
+  if (limitRaw !== undefined) {
+    const parsed = Number.parseInt(limitRaw, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      return c.json({ error: "limit must be a positive integer" }, 400);
+    }
+    limit = Math.min(parsed, 500);
+  }
+
+  let offset = 0;
+  if (offsetRaw !== undefined) {
+    const parsed = Number.parseInt(offsetRaw, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return c.json({ error: "offset must be a non-negative integer" }, 400);
+    }
+    offset = parsed;
+  }
+
+  const db = getDb();
+  const conditions: string[] = [];
+  const params: Array<string | number> = [];
+
+  if (owner) {
+    conditions.push("owner = ?");
+    params.push(owner);
+  }
+  if (project) {
+    conditions.push("project = ?");
+    params.push(project);
+  }
+  if (eventType) {
+    conditions.push("event_type = ?");
+    params.push(eventType);
+  }
+  if (knowledgeId) {
+    conditions.push("knowledge_id = ?");
+    params.push(knowledgeId);
+  }
+  if (sinceCutoff) {
+    conditions.push("created_at >= ?");
+    params.push(sinceCutoff);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const countRow = db.prepare(`SELECT COUNT(*) AS cnt FROM audit_events ${whereClause}`).get(...params) as { cnt: number };
+  const rows = db.prepare(
+    `SELECT id, event_type, knowledge_id, owner, project, actor_key_id, changed_fields, created_at
+     FROM audit_events
+     ${whereClause}
+     ORDER BY created_at DESC, id DESC
+     LIMIT ? OFFSET ?`,
+  ).all(...params, limit, offset) as AuditEventRow[];
+
+  return c.json({
+    items: rows.map(auditEventToJson),
+    total: countRow.cnt,
+  });
+});
+
 // 1. POST /api/knowledge
 api.post("/knowledge", async (c) => {
   const auth = requireApiAuth(c);
@@ -817,7 +988,9 @@ api.post("/knowledge", async (c) => {
 
   const db = getDb();
   const body = await c.req.json() as PublishKnowledgeInput;
-  const result = await publishKnowledgeItem(db, auth.owner, body);
+  const result = await publishKnowledgeItem(db, auth.owner, body, {
+    actorKeyId: auth.id,
+  });
   if (!result.ok) {
     return c.json({ error: result.error }, result.status as 400);
   }
@@ -930,7 +1103,10 @@ api.post("/tasks/:task_id/end", async (c) => {
   const findings = (body.findings as PublishKnowledgeInput[] | undefined) ?? [];
 
   for (let index = 0; index < findings.length; index += 1) {
-    const result = await publishKnowledgeItem(db, auth.owner, findings[index]!, task.task_id);
+    const result = await publishKnowledgeItem(db, auth.owner, findings[index]!, {
+      taskId: task.task_id,
+      actorKeyId: auth.id,
+    });
     if (!result.ok) {
       return c.json({
         task_id: task.task_id,
@@ -1439,14 +1615,47 @@ api.patch("/knowledge/:id", async (c) => {
   if (attempted.length > 0) return c.json({ error: `Cannot modify immutable fields: ${attempted.join(", ")}` }, 400);
   const updates: string[] = [];
   const params: (string | number)[] = [];
-  if (body.tags !== undefined) { if (!Array.isArray(body.tags)) return c.json({ error: "tags must be an array" }, 400); updates.push("tags = ?"); params.push(JSON.stringify(body.tags)); }
-  if (body.confidence !== undefined) { if (!VALID_CONFIDENCE.has(body.confidence)) return c.json({ error: "confidence must be one of: high, medium, low" }, 400); updates.push("confidence = ?"); params.push(body.confidence); }
-  if (body.staleness_hint !== undefined) { updates.push("staleness_hint = ?"); params.push(body.staleness_hint); }
-  if (body.related_to !== undefined) { if (!Array.isArray(body.related_to)) return c.json({ error: "related_to must be an array" }, 400); updates.push("related_to = ?"); params.push(JSON.stringify(body.related_to)); }
+  const changedFields: string[] = [];
+  if (body.tags !== undefined) {
+    if (!Array.isArray(body.tags)) return c.json({ error: "tags must be an array" }, 400);
+    const serializedTags = JSON.stringify(body.tags);
+    updates.push("tags = ?");
+    params.push(serializedTags);
+    if (serializedTags !== row.tags) changedFields.push("tags");
+  }
+  if (body.confidence !== undefined) {
+    if (!VALID_CONFIDENCE.has(body.confidence)) return c.json({ error: "confidence must be one of: high, medium, low" }, 400);
+    updates.push("confidence = ?");
+    params.push(body.confidence);
+    if (body.confidence !== row.confidence) changedFields.push("confidence");
+  }
+  if (body.staleness_hint !== undefined) {
+    updates.push("staleness_hint = ?");
+    params.push(body.staleness_hint);
+    if (body.staleness_hint !== row.staleness_hint) changedFields.push("staleness_hint");
+  }
+  if (body.related_to !== undefined) {
+    if (!Array.isArray(body.related_to)) return c.json({ error: "related_to must be an array" }, 400);
+    const serializedRelatedTo = JSON.stringify(body.related_to);
+    updates.push("related_to = ?");
+    params.push(serializedRelatedTo);
+    if (serializedRelatedTo !== row.related_to) changedFields.push("related_to");
+  }
   if (updates.length === 0) return c.json({ error: "No valid fields to update" }, 400);
   const now = new Date().toISOString();
   updates.push("updated_at = ?"); params.push(now); params.push(id);
-  db.prepare(`UPDATE knowledge SET ${updates.join(", ")} WHERE id = ?`).run(...params);
+  db.transaction(() => {
+    db.prepare(`UPDATE knowledge SET ${updates.join(", ")} WHERE id = ?`).run(...params);
+    recordAuditEvent(db, {
+      eventType: "update",
+      knowledgeId: id,
+      owner: auth.owner,
+      project: row.project,
+      actorKeyId: auth.id,
+      changedFields,
+      createdAt: now,
+    });
+  })();
   const updated = db.prepare("SELECT * FROM knowledge WHERE id = ?").get(id) as KnowledgeRow;
   return c.json(rowToJson(updated));
 });

--- a/packages/backend/tests/audit-log.test.ts
+++ b/packages/backend/tests/audit-log.test.ts
@@ -1,0 +1,381 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, afterEach, before, test } from "node:test";
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "team-memory-audit-log-"));
+const dbPath = path.join(tempDir, "team-memory.db");
+
+process.env.TEAM_MEMORY_DB = dbPath;
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+let createStoredApiKey: typeof import("../src/api-keys.ts").createApiKey;
+
+function adminHeaders(key = process.env.TEAM_MEMORY_ADMIN_KEY ?? "tm_admin_test"): HeadersInit {
+  return {
+    authorization: `Bearer ${key}`,
+  };
+}
+
+function apiHeaders(key: string): HeadersInit {
+  return {
+    authorization: `Bearer ${key}`,
+    "content-type": "application/json",
+  };
+}
+
+function insertKnowledgeRow(
+  db: Database.Database,
+  input: {
+    id: string;
+    owner: string;
+    claim?: string;
+    project?: string;
+  },
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO knowledge (
+      id, claim, detail, source, project, module, tags, confidence,
+      staleness_hint, owner, related_to, supersedes, superseded_by,
+      duplicate_of, embedding, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.claim ?? `Claim for ${input.id}`,
+    null,
+    JSON.stringify(["tests/audit-log.test.ts"]),
+    input.project ?? "alpha",
+    "audit",
+    JSON.stringify(["audit"]),
+    "high",
+    "Recheck if audit semantics change.",
+    input.owner,
+    JSON.stringify([]),
+    null,
+    null,
+    null,
+    null,
+    now,
+    now,
+  );
+}
+
+function insertAuditEvent(
+  db: Database.Database,
+  input: {
+    eventType: "publish" | "update" | "supersede" | "delete";
+    knowledgeId: string;
+    owner: string;
+    project: string | null;
+    actorKeyId?: string | null;
+    changedFields?: string[] | null;
+    createdAt: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO audit_events (
+      event_type, knowledge_id, owner, project, actor_key_id, changed_fields, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.eventType,
+    input.knowledgeId,
+    input.owner,
+    input.project,
+    input.actorKeyId ?? null,
+    input.changedFields ? JSON.stringify(input.changedFields) : null,
+    input.createdAt,
+  );
+}
+
+before(async () => {
+  const routesModule = await import("../src/routes.ts");
+  const dbModule = await import("../src/db.ts");
+  const apiKeysModule = await import("../src/api-keys.ts");
+
+  const honoApp = new Hono();
+  honoApp.route("/api", routesModule.api);
+
+  app = honoApp;
+  getDb = dbModule.getDb;
+  closeDb = dbModule.closeDb;
+  createStoredApiKey = apiKeysModule.createApiKey;
+});
+
+afterEach(() => {
+  delete process.env.TEAM_MEMORY_ADMIN_KEY;
+  const db = getDb();
+  db.exec("DELETE FROM audit_events; DELETE FROM task_publications; DELETE FROM reuse_feedback; DELETE FROM usage_events; DELETE FROM tasks; DELETE FROM knowledge; DELETE FROM api_keys;");
+});
+
+after(() => {
+  delete process.env.TEAM_MEMORY_DB;
+  delete process.env.TEAM_MEMORY_ADMIN_KEY;
+  closeDb();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("POST /api/knowledge writes a publish audit event with the actor key id", async () => {
+  const db = getDb();
+  const record = createStoredApiKey(db, {
+    owner: "Alice",
+    defaultProjects: ["alpha"],
+  });
+
+  const response = await app.request("http://localhost/api/knowledge", {
+    method: "POST",
+    headers: apiHeaders(record.key),
+    body: JSON.stringify({
+      claim: "Publish audit event",
+      source: ["tests/audit-log.test.ts"],
+      project: "alpha",
+      tags: ["audit"],
+      confidence: "high",
+      staleness_hint: "Recheck if publish audit behavior changes.",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  const body = await response.json() as { id: string };
+
+  const rows = db.prepare(
+    `SELECT id, event_type, knowledge_id, owner, project, actor_key_id, changed_fields, created_at
+     FROM audit_events
+     ORDER BY id ASC`,
+  ).all() as Array<{
+    event_type: string;
+    knowledge_id: string;
+    owner: string;
+    project: string | null;
+    actor_key_id: string | null;
+    changed_fields: string | null;
+  }>;
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]!.event_type, "publish");
+  assert.equal(rows[0]!.knowledge_id, body.id);
+  assert.equal(rows[0]!.owner, "Alice");
+  assert.equal(rows[0]!.project, "alpha");
+  assert.equal(rows[0]!.actor_key_id, record.id);
+  assert.equal(rows[0]!.changed_fields, null);
+});
+
+test("PATCH /api/knowledge/:id writes update audit row with exactly the changed fields", async () => {
+  const db = getDb();
+  const record = createStoredApiKey(db, {
+    owner: "Alice",
+    defaultProjects: ["alpha"],
+  });
+  insertKnowledgeRow(db, { id: "alpha-note", owner: "Alice", project: "alpha" });
+
+  const response = await app.request("http://localhost/api/knowledge/alpha-note", {
+    method: "PATCH",
+    headers: apiHeaders(record.key),
+    body: JSON.stringify({
+      tags: ["audit", "updated"],
+      confidence: "high",
+      staleness_hint: "Updated staleness hint",
+      related_to: [],
+    }),
+  });
+
+  assert.equal(response.status, 200);
+
+  const row = db.prepare(
+    `SELECT id, event_type, knowledge_id, owner, project, actor_key_id, changed_fields, created_at
+     FROM audit_events
+     ORDER BY id DESC
+     LIMIT 1`,
+  ).get() as {
+    event_type: string;
+    knowledge_id: string;
+    owner: string;
+    project: string | null;
+    actor_key_id: string | null;
+    changed_fields: string | null;
+  };
+
+  assert.equal(row.event_type, "update");
+  assert.equal(row.knowledge_id, "alpha-note");
+  assert.equal(row.owner, "Alice");
+  assert.equal(row.project, "alpha");
+  assert.equal(row.actor_key_id, record.id);
+  assert.deepEqual(JSON.parse(row.changed_fields ?? "[]"), ["tags", "staleness_hint"]);
+});
+
+test("publishing with supersedes writes publish and supersede audit rows", async () => {
+  const db = getDb();
+  const record = createStoredApiKey(db, {
+    owner: "Alice",
+    defaultProjects: ["alpha"],
+  });
+  insertKnowledgeRow(db, { id: "old-note", owner: "Bob", project: "alpha" });
+
+  const response = await app.request("http://localhost/api/knowledge", {
+    method: "POST",
+    headers: apiHeaders(record.key),
+    body: JSON.stringify({
+      claim: "New superseding knowledge",
+      source: ["tests/audit-log.test.ts"],
+      project: "alpha",
+      tags: ["audit"],
+      confidence: "high",
+      staleness_hint: "Recheck if supersede logging changes.",
+      supersedes: "old-note",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  const body = await response.json() as { id: string };
+
+  const rows = db.prepare(
+    `SELECT event_type, knowledge_id, owner, project, actor_key_id
+     FROM audit_events
+     ORDER BY id ASC`,
+  ).all() as Array<{
+    event_type: string;
+    knowledge_id: string;
+    owner: string;
+    project: string | null;
+    actor_key_id: string | null;
+  }>;
+
+  assert.equal(rows.length, 2);
+  assert.deepEqual(
+    rows.map((row) => ({
+      event_type: row.event_type,
+      knowledge_id: row.knowledge_id,
+      owner: row.owner,
+      project: row.project,
+      actor_key_id: row.actor_key_id,
+    })),
+    [
+      {
+        event_type: "publish",
+        knowledge_id: body.id,
+        owner: "Alice",
+        project: "alpha",
+        actor_key_id: record.id,
+      },
+      {
+        event_type: "supersede",
+        knowledge_id: "old-note",
+        owner: "Alice",
+        project: "alpha",
+        actor_key_id: record.id,
+      },
+    ],
+  );
+});
+
+test("GET /api/admin/audit-log paginates and respects filter combinations", async () => {
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+  const db = getDb();
+  insertAuditEvent(db, {
+    eventType: "publish",
+    knowledgeId: "alpha-new",
+    owner: "Alice",
+    project: "alpha",
+    createdAt: new Date().toISOString(),
+  });
+  insertAuditEvent(db, {
+    eventType: "update",
+    knowledgeId: "alpha-updated",
+    owner: "Alice",
+    project: "alpha",
+    changedFields: ["tags"],
+    createdAt: new Date().toISOString(),
+  });
+  insertAuditEvent(db, {
+    eventType: "publish",
+    knowledgeId: "beta-new",
+    owner: "Bob",
+    project: "beta",
+    createdAt: new Date().toISOString(),
+  });
+  insertAuditEvent(db, {
+    eventType: "supersede",
+    knowledgeId: "old-alpha",
+    owner: "Alice",
+    project: "alpha",
+    createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+  });
+
+  const filteredResponse = await app.request(
+    "http://localhost/api/admin/audit-log?owner=Alice&project=alpha&event_type=publish&since=1d",
+    {
+      headers: adminHeaders(),
+    },
+  );
+  assert.equal(filteredResponse.status, 200);
+  const filteredBody = await filteredResponse.json() as {
+    items: Array<{
+      event_type: string;
+      knowledge_id: string;
+      owner: string;
+      project: string | null;
+      actor_key_id: string | null;
+      changed_fields: string[] | null;
+    }>;
+    total: number;
+  };
+  assert.equal(filteredBody.total, 1);
+  assert.equal(filteredBody.items.length, 1);
+  assert.equal(filteredBody.items[0]!.event_type, "publish");
+  assert.equal(filteredBody.items[0]!.knowledge_id, "alpha-new");
+  assert.equal(filteredBody.items[0]!.owner, "Alice");
+  assert.equal(filteredBody.items[0]!.project, "alpha");
+  assert.equal(filteredBody.items[0]!.actor_key_id, null);
+  assert.equal(filteredBody.items[0]!.changed_fields, null);
+
+  const knowledgeResponse = await app.request(
+    "http://localhost/api/admin/audit-log?knowledge_id=alpha-updated",
+    {
+      headers: adminHeaders(),
+    },
+  );
+  assert.equal(knowledgeResponse.status, 200);
+  const knowledgeBody = await knowledgeResponse.json() as {
+    items: Array<{
+      knowledge_id: string;
+      event_type: string;
+      changed_fields: string[] | null;
+    }>;
+    total: number;
+  };
+  assert.equal(knowledgeBody.total, 1);
+  assert.equal(knowledgeBody.items[0]!.knowledge_id, "alpha-updated");
+  assert.equal(knowledgeBody.items[0]!.event_type, "update");
+  assert.deepEqual(knowledgeBody.items[0]!.changed_fields, ["tags"]);
+
+  const paginatedResponse = await app.request(
+    "http://localhost/api/admin/audit-log?limit=1&offset=1",
+    {
+      headers: adminHeaders(),
+    },
+  );
+  assert.equal(paginatedResponse.status, 200);
+  const paginatedBody = await paginatedResponse.json() as {
+    items: Array<{ knowledge_id: string }>;
+    total: number;
+  };
+  assert.equal(paginatedBody.total, 4);
+  assert.equal(paginatedBody.items.length, 1);
+});
+
+test("GET /api/admin/audit-log returns 404 without a valid admin credential", async () => {
+  const disabledResponse = await app.request("http://localhost/api/admin/audit-log");
+  assert.equal(disabledResponse.status, 404);
+
+  process.env.TEAM_MEMORY_ADMIN_KEY = "tm_admin_secret";
+  const wrongAuthResponse = await app.request("http://localhost/api/admin/audit-log", {
+    headers: adminHeaders("tm_admin_wrong"),
+  });
+  assert.equal(wrongAuthResponse.status, 404);
+});


### PR DESCRIPTION
## Summary
- add `audit_events` schema with created-at index and actor-key linkage
- instrument publish/update/supersede write paths and expose `GET /api/admin/audit-log`
- add backend coverage for publish, update, supersede, admin filtering/pagination, and 404 admin gating

## Validation
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" node --import tsx --test packages/backend/tests/audit-log.test.ts`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" npm test --workspace=packages/backend`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" npm run build --workspace=packages/backend`

Closes #46
