### PR TITLE
feat(dashboard): add Audit Log tab

### DIFF
--- a/packages/dashboard/src/App.css
+++ b/packages/dashboard/src/App.css
@@ -836,6 +836,157 @@
   background: var(--bg-secondary);
 }
 
+/* Audit log view */
+.audit-view {
+  flex: 1;
+  padding: 24px;
+  overflow-y: auto;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.audit-table {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.audit-table-head,
+.audit-row {
+  display: grid;
+  grid-template-columns: 140px 90px 120px 100px 1fr 1fr;
+  gap: 12px;
+  padding: 10px 14px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.audit-table-head {
+  background: var(--bg-secondary);
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border);
+}
+
+.audit-row {
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.audit-row:last-child {
+  border-bottom: none;
+}
+
+.audit-row:hover {
+  background: var(--bg-secondary);
+}
+
+.audit-col-time {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.audit-col-owner {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-col-project {
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-knowledge-id {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-col-changes {
+  color: var(--text-dim);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-event-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.audit-event-badge.publish {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.audit-event-badge.update {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.audit-event-badge.supersede {
+  background: rgba(234, 179, 8, 0.15);
+  color: #a16207;
+}
+
+.audit-event-badge.delete {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.audit-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.audit-pagination button {
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.audit-pagination button:hover:not(:disabled) {
+  background: var(--accent-bg);
+}
+
+.audit-pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.audit-page-info {
+  font-size: 13px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
 @media (max-width: 1280px) {
   .reuse-cards {
     grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import type { KnowledgeItem, KnowledgeListItem, ReuseReport, ReuseSince } from "./types";
+import type { KnowledgeItem, KnowledgeListItem, ReuseReport, ReuseSince, AuditEvent, AuditEventType } from "./types";
 import {
   listKnowledge,
   searchKnowledge,
@@ -8,10 +8,11 @@ import {
   getApiKey,
   setApiKey,
   getReuseReport,
+  getAuditLog,
 } from "./api";
 import "./App.css";
 
-type View = "knowledge" | "reuse";
+type View = "knowledge" | "reuse" | "audit";
 
 function App() {
   const [items, setItems] = useState<KnowledgeListItem[]>([]);
@@ -99,6 +100,12 @@ function App() {
           >
             Reuse
           </button>
+          <button
+            className={`view-tab ${view === "audit" ? "active" : ""}`}
+            onClick={() => setView("audit")}
+          >
+            Audit Log
+          </button>
         </nav>
         {view === "knowledge" && (
           <span className="stats">
@@ -147,7 +154,13 @@ function App() {
         </div>
       )}
 
-      {view === "reuse" ? (
+      {view === "audit" ? (
+        <AuditView
+          projects={projects}
+          owners={owners}
+          onNavigate={(id) => { setView("knowledge"); selectItem(id); }}
+        />
+      ) : view === "reuse" ? (
         <ReuseView
           projects={projects}
           onNavigate={(id) => { setView("knowledge"); selectItem(id); }}
@@ -698,6 +711,195 @@ function ReuseView({
       )}
     </div>
   );
+}
+
+const AUDIT_EVENT_TYPES: AuditEventType[] = ["publish", "update", "supersede", "delete"];
+const PAGE_SIZE = 50;
+
+function AuditView({
+  projects,
+  owners,
+  onNavigate,
+}: {
+  projects: string[];
+  owners: string[];
+  onNavigate: (id: string) => void;
+}) {
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [total, setTotal] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [eventType, setEventType] = useState<AuditEventType | "">("");
+  const [ownerFilter, setOwnerFilter] = useState("");
+  const [projectFilter, setProjectFilter] = useState("");
+  const [since, setSince] = useState("7d");
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    setPage(0);
+  }, [eventType, ownerFilter, projectFilter, since]);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    getAuditLog({
+      event_type: eventType || undefined,
+      owner: ownerFilter || undefined,
+      project: projectFilter || undefined,
+      since: since || undefined,
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    })
+      .then((r) => {
+        setEvents(r.items);
+        setTotal(r.total);
+        setLoading(false);
+      })
+      .catch((e) => {
+        setError(String(e));
+        setEvents([]);
+        setTotal(0);
+        setLoading(false);
+      });
+  }, [eventType, ownerFilter, projectFilter, since, page]);
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  return (
+    <div className="audit-view">
+      <section className="reuse-toolbar">
+        <div className="reuse-toolbar-group">
+          <span className="reuse-toolbar-label">Event</span>
+          <select
+            className="reuse-select"
+            value={eventType}
+            onChange={(e) => setEventType(e.target.value as AuditEventType | "")}
+          >
+            <option value="">All</option>
+            {AUDIT_EVENT_TYPES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+        </div>
+        <div className="reuse-toolbar-group">
+          <span className="reuse-toolbar-label">Owner</span>
+          <select
+            className="reuse-select"
+            value={ownerFilter}
+            onChange={(e) => setOwnerFilter(e.target.value)}
+          >
+            <option value="">All</option>
+            {owners.map((o) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </div>
+        <div className="reuse-toolbar-group">
+          <span className="reuse-toolbar-label">Project</span>
+          <select
+            className="reuse-select"
+            value={projectFilter}
+            onChange={(e) => setProjectFilter(e.target.value)}
+          >
+            <option value="">All</option>
+            {projects.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+        </div>
+        <div className="reuse-toolbar-group">
+          <span className="reuse-toolbar-label">Since</span>
+          <div className="reuse-toggle">
+            {["7d", "30d", ""].map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                className={`reuse-toggle-btn ${since === opt ? "active" : ""}`}
+                onClick={() => setSince(opt)}
+              >
+                {opt === "7d" ? "7 days" : opt === "30d" ? "30 days" : "All"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="reuse-toolbar-spacer" />
+        <span className="reuse-toolbar-status">
+          {loading ? "Loading..." : `${total} event${total !== 1 ? "s" : ""}`}
+        </span>
+      </section>
+
+      {error ? (
+        <div className="reuse-error">
+          <div className="title">Failed to load audit log</div>
+          <div>{error.includes("404") ? "Admin key required — set it via the key button above" : error}</div>
+        </div>
+      ) : events.length === 0 && !loading ? (
+        <div className="reuse-empty">No audit events found.</div>
+      ) : (
+        <>
+          <div className="audit-table">
+            <div className="audit-table-head">
+              <span className="audit-col-time">Time</span>
+              <span className="audit-col-type">Event</span>
+              <span className="audit-col-owner">Owner</span>
+              <span className="audit-col-project">Project</span>
+              <span className="audit-col-id">Knowledge ID</span>
+              <span className="audit-col-changes">Changes</span>
+            </div>
+            {events.map((evt) => (
+              <div
+                key={evt.id}
+                className="audit-row"
+                onClick={() => onNavigate(evt.knowledge_id)}
+              >
+                <span className="audit-col-time">{formatDateTime(evt.created_at)}</span>
+                <span className="audit-col-type">
+                  <span className={`audit-event-badge ${evt.event_type}`}>{evt.event_type}</span>
+                </span>
+                <span className="audit-col-owner">{evt.owner}</span>
+                <span className="audit-col-project">{evt.project ?? "—"}</span>
+                <span className="audit-col-id audit-knowledge-id">{evt.knowledge_id}</span>
+                <span className="audit-col-changes">
+                  {evt.changed_fields ? Object.keys(evt.changed_fields).join(", ") : "—"}
+                </span>
+              </div>
+            ))}
+          </div>
+          {totalPages > 1 && (
+            <div className="audit-pagination">
+              <button
+                disabled={page === 0}
+                onClick={() => setPage(page - 1)}
+              >
+                Prev
+              </button>
+              <span className="audit-page-info">
+                Page {page + 1} of {totalPages}
+              </span>
+              <button
+                disabled={page >= totalPages - 1}
+                onClick={() => setPage(page + 1)}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
 }
 
 function MetricCard({

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -7,6 +7,8 @@ import {
   getAllFilters,
   getApiKey,
   setApiKey,
+  getAdminKey,
+  setAdminKey,
   getReuseReport,
   getAuditLog,
 } from "./api";
@@ -29,6 +31,7 @@ function App() {
   const [searchMode, setSearchMode] = useState<"fts" | "semantic" | "hybrid" | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [apiKeyInput, setApiKeyInput] = useState(getApiKey() ?? "");
+  const [adminKeyInput, setAdminKeyInput] = useState(getAdminKey() ?? "");
   const [view, setView] = useState<View>("knowledge");
 
   useEffect(() => {
@@ -117,7 +120,7 @@ function App() {
           onClick={() => setShowSettings(!showSettings)}
           title="API Key Settings"
         >
-          {getApiKey() ? "🔑" : "⚙"}
+          {getApiKey() || getAdminKey() ? "🔑" : "⚙"}
         </button>
       </header>
 
@@ -129,22 +132,34 @@ function App() {
               type="password"
               value={apiKeyInput}
               onChange={(e) => setApiKeyInput(e.target.value)}
-              placeholder="Enter API key for write operations"
+              placeholder="Bearer token for read endpoints"
+            />
+          </label>
+          <label>
+            Admin Key:
+            <input
+              type="password"
+              value={adminKeyInput}
+              onChange={(e) => setAdminKeyInput(e.target.value)}
+              placeholder="Admin key for audit log"
             />
           </label>
           <button
             onClick={() => {
               setApiKey(apiKeyInput || null);
+              setAdminKey(adminKeyInput || null);
               setShowSettings(false);
             }}
           >
             Save
           </button>
-          {getApiKey() && (
+          {(getApiKey() || getAdminKey()) && (
             <button
               onClick={() => {
                 setApiKey(null);
                 setApiKeyInput("");
+                setAdminKey(null);
+                setAdminKeyInput("");
                 setShowSettings(false);
               }}
             >

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -3,6 +3,8 @@ import type {
   KnowledgeListItem,
   ReuseReport,
   ReuseReportParams,
+  AuditLogParams,
+  AuditLogResponse,
 } from "./types";
 import { mockKnowledge, mockReuseReport } from "./mockData";
 
@@ -203,6 +205,20 @@ export async function getReuseReport(params: ReuseReportParams = {}): Promise<Re
   if (params.min_age_days !== undefined) {
     url.searchParams.set("min_age_days", String(params.min_age_days));
   }
+  const res = await fetch(url, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function getAuditLog(params: AuditLogParams = {}): Promise<AuditLogResponse> {
+  const url = new URL(`${API_BASE}/admin/audit-log`);
+  if (params.owner) url.searchParams.set("owner", params.owner);
+  if (params.project) url.searchParams.set("project", params.project);
+  if (params.event_type) url.searchParams.set("event_type", params.event_type);
+  if (params.knowledge_id) url.searchParams.set("knowledge_id", params.knowledge_id);
+  if (params.since) url.searchParams.set("since", params.since);
+  if (params.limit !== undefined) url.searchParams.set("limit", String(params.limit));
+  if (params.offset !== undefined) url.searchParams.set("offset", String(params.offset));
   const res = await fetch(url, { headers: authHeaders() });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -13,6 +13,7 @@ const USE_MOCK = false;
 const USE_REUSE_MOCK = false;
 
 let _apiKey: string | null = localStorage.getItem("tm_api_key");
+let _adminKey: string | null = localStorage.getItem("tm_admin_key");
 
 export function setApiKey(key: string | null) {
   _apiKey = key;
@@ -27,9 +28,29 @@ export function getApiKey(): string | null {
   return _apiKey;
 }
 
+export function setAdminKey(key: string | null) {
+  _adminKey = key;
+  if (key) {
+    localStorage.setItem("tm_admin_key", key);
+  } else {
+    localStorage.removeItem("tm_admin_key");
+  }
+}
+
+export function getAdminKey(): string | null {
+  return _adminKey;
+}
+
 export function authHeaders(): Record<string, string> {
   if (_apiKey) {
     return { Authorization: `Bearer ${_apiKey}` };
+  }
+  return {};
+}
+
+function adminAuthHeaders(): Record<string, string> {
+  if (_adminKey) {
+    return { Authorization: `Bearer ${_adminKey}` };
   }
   return {};
 }
@@ -219,7 +240,7 @@ export async function getAuditLog(params: AuditLogParams = {}): Promise<AuditLog
   if (params.since) url.searchParams.set("since", params.since);
   if (params.limit !== undefined) url.searchParams.set("limit", String(params.limit));
   if (params.offset !== undefined) url.searchParams.set("offset", String(params.offset));
-  const res = await fetch(url, { headers: authHeaders() });
+  const res = await fetch(url, { headers: adminAuthHeaders() });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -82,3 +82,31 @@ export interface ReuseReportParams {
   project?: string;
   min_age_days?: number;
 }
+
+export type AuditEventType = "publish" | "update" | "supersede" | "delete";
+
+export interface AuditEvent {
+  id: number;
+  event_type: AuditEventType;
+  knowledge_id: string;
+  owner: string;
+  project: string | null;
+  actor_key_id: string | null;
+  changed_fields: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface AuditLogParams {
+  owner?: string;
+  project?: string;
+  event_type?: AuditEventType;
+  knowledge_id?: string;
+  since?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AuditLogResponse {
+  items: AuditEvent[];
+  total: number;
+}


### PR DESCRIPTION
## Summary
- Adds third dashboard tab "Audit Log" for admin-level write-event visibility
- Consumes `GET /api/admin/audit-log` from PR #71 (A6 write-side audit log)
- Filters: event type (publish/update/supersede/delete), owner, project, time window (7d/30d/all)
- Cursor pagination (50 per page)
- Requires admin key set via existing API Key setting (dark 404 on missing/wrong key)
- Color-coded event type badges, click-through to knowledge item detail

## Depends on
- PR #71 (audit-log backend) — must merge first

## Test plan
- [ ] Set admin key in dashboard settings, verify audit events load
- [ ] Verify filter dropdowns (event type, owner, project, since) narrow results correctly
- [ ] Verify pagination controls work with >50 events
- [ ] Verify 404 handling shows "Admin key required" message when no key / wrong key set
- [ ] Click an audit row → navigates to Knowledge tab with that item selected
- [ ] `npm run build --workspace=packages/dashboard` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)