### PR TITLE
feat: pin :latest Docker publish to primitive-batch tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker
 on:
   push:
     branches: [main]
+    tags: ['primitive-batch-*']
   pull_request:
     branches: [main]
 
@@ -18,6 +19,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Derive batch number from tag
+        id: batch
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/primitive-batch-* ]]; then
+            BATCH="${GITHUB_REF#refs/tags/primitive-batch-}"
+            echo "number=$BATCH" >> "$GITHUB_OUTPUT"
+            echo "is_batch=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=" >> "$GITHUB_OUTPUT"
+            echo "is_batch=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -37,6 +50,8 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: team-memory:ci
+          build-args: |
+            PRIMITIVE_BATCH=${{ steps.batch.outputs.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -57,13 +72,25 @@ jobs:
           done
           BODY=$(curl -s http://127.0.0.1:3456/health)
           echo "Response: $BODY"
-          if [ "$BODY" != '{"status":"ok"}' ]; then
-            echo "Unexpected health body"
-            exit 1
-          fi
+          STATUS=$(echo "$BODY" | node -e "process.stdin.on('data',d=>{const j=JSON.parse(d);process.exit(j.status==='ok'?0:1)})")
           docker logs tm-smoke
           docker stop tm-smoke
           docker rm tm-smoke
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          TAGS="${IMAGE}:sha-${GITHUB_SHA}"
+          if [ "${{ steps.batch.outputs.is_batch }}" = "true" ]; then
+            TAGS="${TAGS}
+          ${IMAGE}:latest
+          ${IMAGE}:batch-${{ steps.batch.outputs.number }}"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Push image to GHCR
         if: github.event_name == 'push'
@@ -72,8 +99,8 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:sha-${{ github.sha }}
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            PRIMITIVE_BATCH=${{ steps.batch.outputs.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,11 +46,7 @@ jobs:
           done
           BODY=$(curl -s http://127.0.0.1:3456/health)
           echo "Response: $BODY"
-          if [ "$BODY" != '{"status":"ok"}' ]; then
-            echo "Unexpected health body"
-            docker logs tm-smoke
-            exit 1
-          fi
+          echo "$BODY" | node -e "process.stdin.on('data',d=>{const j=JSON.parse(d);if(j.status!=='ok'){console.error('Unexpected health status');process.exit(1)}})"
           docker logs tm-smoke
           docker stop tm-smoke
           docker rm tm-smoke

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,11 @@ RUN groupadd --system --gid 1001 teammemory \
   && mkdir -p /data \
   && chown -R teammemory:teammemory /data
 
+ARG PRIMITIVE_BATCH
 ENV NODE_ENV=production
 ENV PORT=3456
 ENV TEAM_MEMORY_DB=/data/team-memory.db
+ENV PRIMITIVE_BATCH=${PRIMITIVE_BATCH}
 
 COPY --from=build --chown=teammemory:teammemory /app/node_modules ./node_modules
 COPY --from=build --chown=teammemory:teammemory /app/packages/backend/dist ./packages/backend/dist

--- a/docs/api.md
+++ b/docs/api.md
@@ -199,8 +199,13 @@ Returns service liveness. No auth.
 **Response — 200**
 
 ```json
-{ "status": "ok" }
+{ "status": "ok", "primitive_batch": "1" }
 ```
+
+| Field | Type | Notes |
+|---|---|---|
+| `status` | `"ok"` | Always `"ok"` on a healthy instance. |
+| `primitive_batch` | `string \| null` | The primitive-batch tag this build was published from. `null` for local dev or untagged builds. Use this to detect backend/MCP API skew. |
 
 ---
 

--- a/docs/mcp-config-template.md
+++ b/docs/mcp-config-template.md
@@ -27,7 +27,7 @@ docker run -d \
 Then verify:
 
 ```bash
-curl http://localhost:3456/health   # → {"status":"ok"}
+curl http://localhost:3456/health   # → {"status":"ok","primitive_batch":null}
 ```
 
 Point your MCP config's `TEAM_MEMORY_URL` at `http://localhost:3456` exactly as in the snippets above — only the backend runtime changed, the MCP server still runs locally from your cloned repo.
@@ -48,8 +48,9 @@ The compose file defines a named volume `team-memory-data` mounted at `/data`, s
 
 | Tag | Meaning |
 |-----|---------|
-| `:latest` | Latest successful build on `main` |
-| `:sha-<commit>` | Immutable build for a specific `main` commit — pin this for pilot teams who need reproducibility |
+| `:latest` | Latest primitive-batch release — only advances when a `primitive-batch-N` tag is pushed, not on every commit |
+| `:batch-N` | Immutable tag for a specific primitive batch (e.g., `:batch-1`) |
+| `:sha-<commit>` | Immutable build for a specific `main` commit — published on every push to `main` |
 
 Only `linux/amd64` is published in the initial release. ARM builds and Kubernetes manifests are deliberately out of scope; add later if adoption warrants.
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,7 +8,12 @@ import { closeDb } from "./db.js";
 const app = new Hono();
 app.use("*", cors());
 app.use("*", logger());
-app.get("/health", (c) => c.json({ status: "ok" }));
+app.get("/health", (c) =>
+  c.json({
+    status: "ok",
+    primitive_batch: process.env.PRIMITIVE_BATCH ?? null,
+  }),
+);
 app.route("/api", api);
 
 const PORT = parseInt(process.env.PORT ?? "3456", 10);

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -11,7 +11,7 @@ app.use("*", logger());
 app.get("/health", (c) =>
   c.json({
     status: "ok",
-    primitive_batch: process.env.PRIMITIVE_BATCH ?? null,
+    primitive_batch: process.env.PRIMITIVE_BATCH || null,
   }),
 );
 app.route("/api", api);


### PR DESCRIPTION
## Summary

- `:latest` Docker tag now only advances when a `primitive-batch-N` git tag is pushed — every push to `main` still publishes `:sha-xxx` for immutable reference
- `/health` response gains a `primitive_batch` field (`string | null`) so integrators can diagnose backend/MCP API skew without grep'ing changelogs
- Smoke tests updated to check `status` field instead of exact body match (tolerant of new fields)
- Dockerfile accepts `PRIMITIVE_BATCH` build arg, baked into the image as env var
- Docs updated: `api.md` health response + `mcp-config-template.md` image tags table

Fixes #67

## Test plan

- [x] `npm run build --workspace=packages/backend` ✅
- [x] `npm test --workspace=packages/backend` ✅ 57/57
- [x] Local `/health` returns `{"status":"ok","primitive_batch":null}` without env var
- [x] Local `/health` returns `{"status":"ok","primitive_batch":"1"}` with `PRIMITIVE_BATCH=1`
- [ ] CI passes (build + Docker smoke)
- [ ] After merge: push `primitive-batch-1` tag → verify `:latest` + `:batch-1` published to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)