### PR TITLE
docs: add Docker deployment quickstart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,16 @@
 # Backend
-PORT=3456                                    # Backend server port (change this if 3456 is occupied, e.g. 3460)
-TEAM_MEMORY_DB=./team-memory.db              # Optional SQLite path; use an absolute path for shared or long-running deployments
-EMBEDDING_API_KEY=                           # Optional; when unset, embedding generation degrades gracefully
-EMBEDDING_API_BASE=https://api.openai.com/v1 # Set to https://openrouter.ai/api/v1 when using OpenRouter
-EMBEDDING_MODEL=text-embedding-3-small       # For OpenRouter, e.g. openai/text-embedding-3-small
-TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD=0.8  # Warn when semantic similarity reaches this threshold
-TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD=0.95 # Persist duplicate_of only above this higher threshold
+PORT=3456                                      # Host port for Docker Compose and backend server port for local node runs
+TEAM_MEMORY_DB=./team-memory.db                # Local node SQLite path; Docker Compose overrides this to /data/team-memory.db
+TEAM_MEMORY_ADMIN_KEY=                         # Optional; enables dark /api/admin/* key-management routes when set
+EMBEDDING_API_KEY=                             # Optional; when unset, embedding generation degrades gracefully
+EMBEDDING_API_BASE=https://api.openai.com/v1   # Set to https://openrouter.ai/api/v1 when using OpenRouter
+EMBEDDING_MODEL=text-embedding-3-small         # For OpenRouter, e.g. openai/text-embedding-3-small
+TEAM_MEMORY_DUPLICATE_WARNING_THRESHOLD=0.8    # Warn when semantic similarity reaches this threshold
+TEAM_MEMORY_DUPLICATE_PERSIST_THRESHOLD=0.95   # Persist duplicate_of only above this higher threshold
+TEAM_MEMORY_STALE_AFTER_DAYS=30                # Number of days before stale_at is set for newly published knowledge
 
 # Dashboard
-VITE_API_BASE=http://localhost:3456/api       # Backend API URL for dashboard; keep this aligned with PORT
+VITE_API_BASE=http://localhost:3456/api         # Backend API URL for dashboard; keep this aligned with PORT
 
 # MCP Server
-TEAM_MEMORY_URL=http://localhost:3456         # Backend URL for MCP server; keep this aligned with PORT
+TEAM_MEMORY_URL=http://localhost:3456           # Backend URL for MCP server; keep this aligned with PORT

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ packages/backend         REST API + SQLite + FTS5 + provider-agnostic semantic s
 | `packages/mcp-server` | MCP tools that proxy agent calls to the backend (see [MCP Tools](#mcp-tools) below) |
 | `packages/dashboard` | Read-only dashboard for browsing, filtering, and inspecting knowledge items; includes a Reuse tab for team reuse metrics |
 | `e2e/scripts` | Demo and smoke scripts that validate publish -> query -> get -> feedback flows |
-| `docs/` | Agent behavior protocol, MCP config template, API reference (`docs/api.md`) |
+| `docs/` | Quickstart, agent behavior protocol, MCP config template, API reference (`docs/api.md`) |
 | `CONTRIBUTING.md` | GitHub workflow, branch naming, review expectations |
 
 ## Core Concept: Knowledge Items
@@ -120,6 +120,10 @@ See [`docs/api.md`](docs/api.md) for the full request/response reference, query 
 
 ## Quick Start
 
+For a 5-minute Docker first run, start with [`docs/quickstart.md`](docs/quickstart.md). It covers `docker compose up`, `/health`, key minting, publishing the first knowledge item, and searching it back.
+
+The rest of this section is the source-checkout development path.
+
 ### Prerequisites
 
 - **Node.js 22** (pinned in `.nvmrc`). Run `nvm use` to switch automatically.
@@ -167,6 +171,16 @@ npm run keys --workspace=packages/backend -- create <owner> --projects alpha,bet
 
 The `create` and `update-key` subcommands require an explicit scope flag — pass `--projects <names>` to scope the key, or `--unscoped` to mint a key with no project restriction. Running without either flag fails loud rather than silently minting an unscoped key.
 
+Capture one key for the curl examples below. Use the same `TEAM_MEMORY_DB` value that the backend process uses:
+
+```bash
+export TEAM_MEMORY_API_KEY="$(
+  TEAM_MEMORY_DB=/absolute/path/to/team-memory.db \
+  npm run keys --workspace=packages/backend -- create quickstart-agent --projects infer-monorepo \
+    | awk -F= '/^key=/{print $2}'
+)"
+```
+
 ### 2. Start the MCP server
 
 Point it at the same backend URL. If you customized `PORT`, update `TEAM_MEMORY_URL` to match:
@@ -205,6 +219,7 @@ The backend port, MCP URL, and dashboard API base must stay aligned.
 
 ```bash
 curl -X POST http://localhost:3460/api/knowledge \
+  -H "Authorization: Bearer $TEAM_MEMORY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "claim": "Infer monorepo uses dual deploy modes: control and inference",
@@ -213,15 +228,15 @@ curl -X POST http://localhost:3460/api/knowledge \
     "module": "core/deploy",
     "tags": ["architecture", "deploy-mode"],
     "confidence": "high",
-    "staleness_hint": "Recheck if DEPLOY_MODE logic changes",
-    "owner": "Jet"
+    "staleness_hint": "Recheck if DEPLOY_MODE logic changes"
   }'
 ```
 
 ### 5. Query it back
 
 ```bash
-curl "http://localhost:3460/api/knowledge/search?q=deploy&project=infer-monorepo"
+curl "http://localhost:3460/api/knowledge/search?q=deploy&project=infer-monorepo" \
+  -H "Authorization: Bearer $TEAM_MEMORY_API_KEY"
 ```
 
 ## How To Use It

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       PORT: 3456
       TEAM_MEMORY_DB: /data/team-memory.db
+      TEAM_MEMORY_ADMIN_KEY: ${TEAM_MEMORY_ADMIN_KEY:-}
       EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
       EMBEDDING_API_BASE: ${EMBEDDING_API_BASE:-https://api.openai.com/v1}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-text-embedding-3-small}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,160 @@
+# Team Memory Quickstart
+
+This is the 5-minute path for standing up one Team Memory instance with Docker, checking that it is healthy, minting an agent key, and publishing the first knowledge item.
+
+For local source development instead of self-hosting, use the development notes in the root [`README.md`](../README.md#quick-start).
+
+## Prerequisites
+
+- Docker with the Compose v2 plugin (`docker compose ...`)
+- `curl`
+- A shell with `awk` for the key-capture one-liner below
+
+No host Node.js install is required for the backend when using Docker. The image already includes Node 22 and native `better-sqlite3` bindings.
+
+## Deployment model
+
+Run one Team Memory instance per team. The instance has its own backend process and SQLite database. Inside that team instance, mint separate API keys for each agent or automation lane so writes keep attribution and optional project scoping.
+
+Team Memory does not add a tenant layer inside one shared database. If you need isolation between teams, run another instance with a separate volume or database path.
+
+## 1. Prepare environment
+
+From the repo root:
+
+```bash
+cp .env.example .env
+```
+
+The defaults are enough for a local first run:
+
+- Backend URL: `http://localhost:3456`
+- SQLite data: Docker named volume `team-memory-data`, mounted at `/data/team-memory.db`
+- Embeddings: disabled unless you set `EMBEDDING_API_KEY`
+
+If port `3456` is occupied, edit `.env` and set `PORT=<free-port>` before starting the service.
+
+## 2. Start the backend
+
+```bash
+docker compose up -d
+```
+
+Follow logs if startup fails:
+
+```bash
+docker compose logs -f backend
+```
+
+## 3. Check health
+
+```bash
+curl -s http://localhost:3456/health
+```
+
+Expected shape:
+
+```json
+{"status":"ok","primitive_batch":null}
+```
+
+`primitive_batch` is a string such as `"1"` for published primitive-batch images, and `null` for local builds or untagged images. Use this field to diagnose backend/MCP API skew when integrating against a Docker image.
+
+## 4. Mint an agent key
+
+Team Memory write endpoints require a Bearer token. Mint a scoped key inside the running container:
+
+```bash
+export TEAM_MEMORY_API_KEY="$(
+  docker compose exec -T backend \
+    node packages/backend/dist/cli.js create quickstart-agent --projects quickstart \
+    | awk -F= '/^key=/{print $2}'
+)"
+```
+
+Confirm the shell captured it:
+
+```bash
+test -n "$TEAM_MEMORY_API_KEY" && echo "key captured"
+```
+
+The CLI requires an explicit scope posture. Use `--projects <names>` for normal team usage. Use `--unscoped` only when you intentionally want no project restriction.
+
+## 5. Publish first knowledge
+
+```bash
+curl -sS -X POST http://localhost:3456/api/knowledge \
+  -H "Authorization: Bearer $TEAM_MEMORY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "claim": "Team Memory Docker quickstart can publish and search a first knowledge item.",
+    "source": ["docs/quickstart.md"],
+    "project": "quickstart",
+    "tags": ["quickstart", "docker"],
+    "confidence": "high",
+    "staleness_hint": "Recheck when docker-compose.yml or the publish API changes."
+  }'
+```
+
+The response body should include an `id`.
+
+Common mistake: `source` and `tags` are arrays, not strings.
+
+## 6. Search it back
+
+```bash
+curl -sS "http://localhost:3456/api/knowledge/search?q=docker&project=quickstart" \
+  -H "Authorization: Bearer $TEAM_MEMORY_API_KEY"
+```
+
+Expected shape:
+
+```json
+{
+  "items": [
+    {
+      "claim": "Team Memory Docker quickstart can publish and search a first knowledge item."
+    }
+  ],
+  "total": 1
+}
+```
+
+The real response includes additional fields such as `id`, `project`, `tags`, and `created_at`.
+
+## 7. Connect an agent
+
+Point your MCP client at the same backend:
+
+```text
+TEAM_MEMORY_URL=http://localhost:3456
+TEAM_MEMORY_API_KEY=<the tm_... key you minted above>
+```
+
+Use [`docs/mcp-config-template.md`](mcp-config-template.md) for Claude, project `.mcp.json`, Codex, and wrapper-based per-agent key delegation examples.
+
+## Stop or reset
+
+Stop without deleting data:
+
+```bash
+docker compose down
+```
+
+Delete the local quickstart database too:
+
+```bash
+docker compose down -v
+```
+
+## Optional: admin key provisioning
+
+The quickstart uses the container CLI because it works without enabling the dark admin surface.
+
+If your launcher or orchestrator needs to mint keys over HTTP, set `TEAM_MEMORY_ADMIN_KEY` in `.env` before `docker compose up -d`, then call `POST /api/admin/keys` with:
+
+```http
+Authorization: Bearer <TEAM_MEMORY_ADMIN_KEY>
+```
+
+See [`docs/api.md#admin-key-management`](api.md#admin-key-management) for the exact request and response contract.


### PR DESCRIPTION
## Summary

Covers #64 §1.

- Adds `docs/quickstart.md` with the 5-minute Docker path: `docker compose up`, `/health`, container CLI key mint, authenticated publish, and search-back verification.
- Updates `.env.example` with the self-host variables external operators need, including `TEAM_MEMORY_ADMIN_KEY` and `TEAM_MEMORY_STALE_AFTER_DAYS`.
- Passes `TEAM_MEMORY_ADMIN_KEY` through `docker-compose.yml` so the documented admin API path can be enabled from `.env`.
- Adds a README pointer to the Docker quickstart and fixes the source-checkout curl example to use an API key.
- Includes the quickstart-side one-instance-per-team note to pair with #76.

## Validation

- `git diff --check` ✅
- `docker compose config` ✅
- Docker smoke on this branch ✅
  - `docker compose up -d --build`
  - `GET /health` returned `{"status":"ok","primitive_batch":null}`
  - container CLI minted a scoped `quickstart-agent` key
  - authenticated `POST /api/knowledge` returned an item id
  - authenticated search found the published quickstart item
  - `docker compose down -v` cleanup completed

@umiri — Docker path validation requested per Faye's dispatch.
